### PR TITLE
Add LVM support

### DIFF
--- a/src/Lvm/DiskArea.cs
+++ b/src/Lvm/DiskArea.cs
@@ -1,0 +1,49 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+
+    internal class DiskArea : IByteArraySerializable
+    {
+        public ulong Offset;
+        public ulong Length;
+        
+        /// <inheritdoc />
+        public int Size { get { return 16; } }
+
+        /// <inheritdoc />
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Offset = Utilities.ToUInt64LittleEndian(buffer, offset);
+            Length = Utilities.ToUInt64LittleEndian(buffer, offset + 0x8);
+            return Size;
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Lvm/LogicalVolumeManager.cs
+++ b/src/Lvm/LogicalVolumeManager.cs
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using DiscUtils.Partitions;
+
+    /// <summary>
+    /// A class that understands Linux LVM structures, mapping physical volumes to logical volumes.
+    /// </summary>
+    public class LogicalVolumeManager
+    {
+        private List<LogicalVolumeInfo> _devices;
+        /// <summary>
+        /// Initializes a new instance of the LogicalVolumeManager class.
+        /// </summary>
+        /// <param name="disks">The initial set of disks to manage.</param>
+        public LogicalVolumeManager(IEnumerable<VirtualDisk> disks)
+        {
+            _devices = new List<LogicalVolumeInfo>();
+            foreach (var disk in disks)
+            {
+                if (disk.IsPartitioned)
+                {
+                    foreach (var partition in disk.Partitions.Partitions)
+                    {
+                        PhysicalVolume pv;
+                        if (PhysicalVolume.TryOpen(partition, out pv))
+                        {
+
+                        }
+                    }
+                }
+                else
+                {
+                    PhysicalVolume pv;
+                    if (PhysicalVolume.TryOpen(disk.Content, out pv))
+                    {
+
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines if a physical volume contains LVM data.
+        /// </summary>
+        /// <param name="volumeInfo">The volume to inspect.</param>
+        /// <returns><c>true</c> if the physical volume contains LVM data, else <c>false</c>.</returns>
+        public static bool HandlesPhysicalVolume(PhysicalVolumeInfo volumeInfo)
+        {
+            var partition = volumeInfo.Partition;
+            if (partition == null) return false;
+            return partition.BiosType == BiosPartitionTypes.LinuxLvm ||
+                   partition.GuidType == GuidPartitionTypes.LinuxLvm;
+        }
+
+        /// <summary>
+        /// Gets the logical volumes held across the set of managed disks.
+        /// </summary>
+        /// <returns>An array of logical volumes.</returns>
+        public LogicalVolumeInfo[] GetLogicalVolumes()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Lvm/LogicalVolumeManagerFactory.cs
+++ b/src/Lvm/LogicalVolumeManagerFactory.cs
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System.Collections.Generic;
+
+    [LogicalVolumeFactory]
+    internal class LogicalVolumeManagerFactory : LogicalVolumeFactory
+    {
+        public override bool HandlesPhysicalVolume(PhysicalVolumeInfo volume)
+        {
+            return LogicalVolumeManager.HandlesPhysicalVolume(volume);
+        }
+
+        public override void MapDisks(IEnumerable<VirtualDisk> disks, Dictionary<string, LogicalVolumeInfo> result)
+        {
+            LogicalVolumeManager mgr = new LogicalVolumeManager(disks);
+            
+            foreach (var vol in mgr.GetLogicalVolumes())
+            {
+                result.Add(vol.Identity, vol);
+            }
+        }
+    }
+}

--- a/src/Lvm/Metadata.cs
+++ b/src/Lvm/Metadata.cs
@@ -1,0 +1,137 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+    internal class Metadata
+    {
+        public DateTime CreationTime;
+        public string CreationHost;
+        public string Description;
+        public string Contents;
+        public int Version;
+        public MetadataVolumeGroupSection[] VolumeGroupSections;
+
+        public static Metadata Parse(string metadata)
+        {
+            using (var reader = new StringReader(metadata))
+            {
+                var result = new Metadata();
+                result.Parse(reader);
+                return result;
+            }
+        }
+
+        private void Parse(TextReader data)
+        {
+            string line;
+            var vgSection = new List<MetadataVolumeGroupSection>();
+            while ((line = ReadLine(data))!= null)
+            {
+                if (line == String.Empty) continue;
+                if (line.Contains("="))
+                {
+                    var parameter = ParseParameter(line);
+                    switch (parameter.Key.Trim().ToLowerInvariant())
+                    {
+                        case "contents":
+                            Contents = ParseStringValue(parameter.Value);
+                            break;
+                        case "version":
+                            Version = (int) ParseNumericValue(parameter.Value);
+                            break;
+                        case "description":
+                            Description = ParseStringValue(parameter.Value);
+                            break;
+                        case "creation_host":
+                            CreationHost = ParseStringValue(parameter.Value);
+                            break;
+                        case "creation_time":
+                            CreationTime = ParseDateTimeValue(parameter.Value);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(parameter.Key, "Unexpected parameter in global metadata");
+                    }
+                }
+                else if (line.EndsWith("{"))
+                {
+                    var vg = new MetadataVolumeGroupSection();
+                    vg.Parse(line, data);
+                    vgSection.Add(vg);
+                }
+            }
+            VolumeGroupSections = vgSection.ToArray();
+        }
+
+
+        internal static string ReadLine(TextReader data)
+        {
+            var line = data.ReadLine();
+            if (line == null) return null;
+            return RemoveComment(line).Trim();
+        }
+
+        internal static string[] ParseArrayValue(string value)
+        {
+            var values = value.Trim('[', ']').Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = Metadata.ParseStringValue(values[i]);
+            }
+            return values;
+        }
+
+        internal static string ParseStringValue(string value)
+        {
+            return value.Trim().Trim('"');
+        }
+
+        internal static DateTime ParseDateTimeValue(string value)
+        {
+            var numeric = ParseNumericValue(value);
+            return new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds(numeric);
+        }
+        internal static ulong ParseNumericValue(string value)
+        {
+            return UInt64.Parse(value.Trim());
+        }
+
+        internal static KeyValuePair<string, string> ParseParameter(string line)
+        {
+            var index = line.IndexOf("=", StringComparison.Ordinal);
+            if (index < 0)
+                throw new ArgumentException("invalid parameter line", line);
+            return new KeyValuePair<string, string>(line.Substring(0,index).Trim(), line.Substring(index+1,line.Length-(index+1)).Trim());
+        }
+
+        internal static string RemoveComment(string line)
+        {
+            var index = line.IndexOf("#", StringComparison.Ordinal);
+            if (index < 0) return line;
+            return line.Substring(0, index);
+        }
+    }
+}

--- a/src/Lvm/MetadataLogicalVolumeSection.cs
+++ b/src/Lvm/MetadataLogicalVolumeSection.cs
@@ -1,0 +1,121 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace DiscUtils.Lvm
+{
+    using System;
+    using System.IO;
+    using System.Collections.Generic;
+
+    internal class MetadataLogicalVolumeSection
+    {
+        public string Name;
+        public string Id;
+        public LogicalVolumeStatus Status;
+        public string[] Flags;
+        public string CreationHost;
+        public DateTime CreationTime;
+        public ulong SegmentCount;
+        public MetadataSegmentSection[] Segments;
+
+        internal void Parse(string head, TextReader data)
+        {
+            var segments = new List<MetadataSegmentSection>();
+            Name = head.Trim().TrimEnd('{').TrimEnd();
+            string line;
+            while ((line = Metadata.ReadLine(data)) != null)
+            {
+                if (line == String.Empty) continue;
+                if (line.Contains("="))
+                {
+                    var parameter = Metadata.ParseParameter(line);
+                    switch (parameter.Key.Trim().ToLowerInvariant())
+                    {
+                        case "id":
+                            Id = Metadata.ParseStringValue(parameter.Value);
+                            break;
+                        case "status":
+                            var values = Metadata.ParseArrayValue(parameter.Value);
+                            foreach (var value in values)
+                            {
+                                switch (value.ToLowerInvariant().Trim())
+                                {
+                                    case "read":
+                                        Status |= LogicalVolumeStatus.Read;
+                                        break;
+                                    case "write":
+                                        Status |= LogicalVolumeStatus.Write;
+                                        break;
+                                    case "visible":
+                                        Status |= LogicalVolumeStatus.Visible;
+                                        break;
+                                    default:
+                                        throw new ArgumentOutOfRangeException("status", "Unexpected status in physical volume metadata");
+                                }
+                            }
+                            break;
+                        case "flags":
+                            Flags = Metadata.ParseArrayValue(parameter.Value);
+                            break;
+                        case "creation_host":
+                            CreationHost = Metadata.ParseStringValue(parameter.Value);
+                            break;
+                        case "creation_time":
+                            CreationTime = Metadata.ParseDateTimeValue(parameter.Value);
+                            break;
+                        case "segment_count":
+                            SegmentCount = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(parameter.Key, "Unexpected parameter in global metadata");
+                    }
+                }
+                else if (line.EndsWith("{"))
+                {
+                    var segment = new MetadataSegmentSection();
+                    segment.Parse(line, data);
+                    segments.Add(segment);
+                }
+                else if (line.EndsWith("}"))
+                {
+                    break;
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException(line, "unexpected input");
+                }
+            }
+            Segments = segments.ToArray();
+        }
+
+    }
+
+    [Flags]
+    internal enum LogicalVolumeStatus
+    {
+        None = 0x0,
+        Read = 0x1,
+        Write = 0x2,
+        Visible = 0x4,
+    }
+}

--- a/src/Lvm/MetadataPhysicalVolumeSection.cs
+++ b/src/Lvm/MetadataPhysicalVolumeSection.cs
@@ -1,0 +1,115 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+    using System.IO;
+
+    internal class MetadataPhysicalVolumeSection
+    {
+        public string Name;
+        public string Id;
+        public string Device;
+        public PhysicalVolumeStatus Status;
+        public string[] Flags;
+        public ulong DeviceSize;
+        public ulong PeStart;
+        public ulong PeCount;
+
+
+        internal void Parse(string head, TextReader data)
+        {
+            Name = head.Trim().TrimEnd('{').TrimEnd();
+            string line;
+            while ((line = Metadata.ReadLine(data)) != null)
+            {
+                if (line == String.Empty) continue;
+                if (line.Contains("="))
+                {
+                    var parameter = Metadata.ParseParameter(line);
+                    switch (parameter.Key.Trim().ToLowerInvariant())
+                    {
+                        case "id":
+                            Id = Metadata.ParseStringValue(parameter.Value);
+                            break;
+                        case "device":
+                            Device = Metadata.ParseStringValue(parameter.Value);
+                            break;
+                        case "status":
+                            var values = Metadata.ParseArrayValue(parameter.Value);
+                            foreach (var value in values)
+                            {
+                                switch (value.ToLowerInvariant().Trim())
+                                {
+                                    case "read":
+                                        Status |= PhysicalVolumeStatus.Read;
+                                        break;
+                                    case "write":
+                                        Status |= PhysicalVolumeStatus.Write;
+                                        break;
+                                    case "allocatable":
+                                        Status |= PhysicalVolumeStatus.Allocatable;
+                                        break;
+                                    default:
+                                        throw new ArgumentOutOfRangeException("status", "Unexpected status in physical volume metadata");
+                                }
+                            }
+                            break;
+                        case "flags":
+                            Flags = Metadata.ParseArrayValue(parameter.Value);
+                            break;
+                        case "dev_size":
+                            DeviceSize = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        case "pe_start":
+                            PeStart = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        case "pe_count":
+                            PeCount = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(parameter.Key, "Unexpected parameter in global metadata");
+                    }
+                }
+                else if (line.EndsWith("}"))
+                {
+                    break;
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException(line, "unexpected input");
+                }
+            }
+        }
+
+    }
+
+    [Flags]
+    internal enum PhysicalVolumeStatus
+    {
+        None = 0x0,
+        Read = 0x1,
+        Write = 0x4,
+        Allocatable = 0x8,
+    }
+}

--- a/src/Lvm/MetadataSegmentSection.cs
+++ b/src/Lvm/MetadataSegmentSection.cs
@@ -1,0 +1,112 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace DiscUtils.Lvm
+{
+    using System;
+    using System.IO;
+    using System.Collections.Generic;
+
+    internal class MetadataSegmentSection
+    {
+        public string Name;
+        public ulong StartExtent;
+        public ulong ExtentCount;
+        public SegmentType Type;
+        public ulong StripeCount;
+        public MetadataStripe[] Stripes;
+
+        internal void Parse(string head, TextReader data)
+        {
+            Name = head.Trim().TrimEnd('{').TrimEnd();
+            string line;
+            while ((line = Metadata.ReadLine(data)) != null)
+            {
+                if (line == String.Empty) continue;
+                if (line.Contains("="))
+                {
+                    var parameter = Metadata.ParseParameter(line);
+                    switch (parameter.Key.Trim().ToLowerInvariant())
+                    {
+                        case "start_extent":
+                            StartExtent = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        case "extent_count":
+                            ExtentCount = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        case "type":
+                            var value = Metadata.ParseStringValue(parameter.Value);
+                            if (value == "striped")
+                                Type = SegmentType.Striped;
+                            break;
+                        case "stripe_count":
+                            StripeCount = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        case "stripes":
+                            if (parameter.Value.Trim() == "[")
+                            {
+                                Stripes = ParseStripesSection(data);
+                            }
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(parameter.Key, "Unexpected parameter in global metadata");
+                    }
+                }
+                else if (line.EndsWith("}"))
+                {
+                    return;
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException(line, "unexpected input");
+                }
+            }
+        }
+
+        private MetadataStripe[] ParseStripesSection(TextReader data)
+        {
+            var result = new List<MetadataStripe>();
+
+            string line;
+            while ((line = Metadata.ReadLine(data)) != null)
+            {
+                if (line == String.Empty) continue;
+                if (line.EndsWith("]"))
+                {
+                    return result.ToArray();
+                }
+                var pv = new MetadataStripe();
+                pv.Parse(line);
+                result.Add(pv);
+            }
+            return result.ToArray();
+        }
+    }
+
+    [Flags]
+    internal enum SegmentType
+    {
+        None,
+        Striped,
+    }
+}

--- a/src/Lvm/MetadataSegmentSection.cs
+++ b/src/Lvm/MetadataSegmentSection.cs
@@ -56,8 +56,69 @@ namespace DiscUtils.Lvm
                             break;
                         case "type":
                             var value = Metadata.ParseStringValue(parameter.Value);
-                            if (value == "striped")
-                                Type = SegmentType.Striped;
+                            switch (value)
+                            {
+                                case "striped":
+                                    Type = SegmentType.Striped;
+                                    break;
+                                case "zero":
+                                    Type = SegmentType.Zero;
+                                    break;
+                                case "error":
+                                    Type = SegmentType.Error;
+                                    break;
+                                case "free":
+                                    Type = SegmentType.Free;
+                                    break;
+                                case "snapshot":
+                                    Type = SegmentType.Snapshot;
+                                    break;
+                                case "mirror":
+                                    Type = SegmentType.Mirror;
+                                    break;
+                                case "raid1":
+                                    Type = SegmentType.Raid1;
+                                    break;
+                                case "raid10":
+                                    Type = SegmentType.Raid10;
+                                    break;
+                                case "raid4":
+                                    Type = SegmentType.Raid4;
+                                    break;
+                                case "raid5":
+                                    Type = SegmentType.Raid5;
+                                    break;
+                                case "raid5_la":
+                                    Type = SegmentType.Raid5La;
+                                    break;
+                                case "raid5_ra":
+                                    Type = SegmentType.Raid5Ra;
+                                    break;
+                                case "raid5_ls":
+                                    Type = SegmentType.Raid5Ls;
+                                    break;
+                                case "raid5_rs":
+                                    Type = SegmentType.Raid5Rs;
+                                    break;
+                                case "raid6":
+                                    Type = SegmentType.Raid6;
+                                    break;
+                                case "raid6_zr":
+                                    Type = SegmentType.Raid6Zr;
+                                    break;
+                                case "raid6_nr":
+                                    Type = SegmentType.Raid6Nr;
+                                    break;
+                                case "raid6_nc":
+                                    Type = SegmentType.Raid6Nc;
+                                    break;
+                                case "thin-pool":
+                                    Type = SegmentType.ThinPool;
+                                    break;
+                                case "thin":
+                                    Type = SegmentType.Thin;
+                                    break;
+                            }
                             break;
                         case "stripe_count":
                             StripeCount = Metadata.ParseNumericValue(parameter.Value);
@@ -106,7 +167,27 @@ namespace DiscUtils.Lvm
     [Flags]
     internal enum SegmentType
     {
+        //$ lvm segtypes, man(8) lvm
         None,
         Striped,
+        Zero,
+        Error,
+        Free,
+        Snapshot,
+        Mirror,
+        Raid1,
+        Raid10,
+        Raid4,
+        Raid5,
+        Raid5La,
+        Raid5Ra,
+        Raid5Ls,
+        Raid5Rs,
+        Raid6,
+        Raid6Zr,
+        Raid6Nr,
+        Raid6Nc,
+        ThinPool,
+        Thin,
     }
 }

--- a/src/Lvm/MetadataStripe.cs
+++ b/src/Lvm/MetadataStripe.cs
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+    using System.IO;
+
+    internal class MetadataStripe
+    {
+        public string PhysicalVolumeName;
+        public ulong StartExtentNumber;
+
+        internal void Parse(string line)
+        {
+            var parts = line.Split(',');
+            if (parts.Length != 2)
+                throw new ArgumentException("invalid stripe format", line);
+            PhysicalVolumeName = Metadata.ParseStringValue(parts[0]);
+            StartExtentNumber = Metadata.ParseNumericValue(parts[1]);
+        }
+    }
+}

--- a/src/Lvm/MetadataVolumeGroupSection.cs
+++ b/src/Lvm/MetadataVolumeGroupSection.cs
@@ -1,0 +1,182 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+    internal class MetadataVolumeGroupSection
+    {
+        public string Name;
+        public string Id;
+        public ulong SequenceNumber;
+        public string Format;
+        public VolumeGroupStatus Status;
+        public string[] Flags;
+        public ulong ExtentSize;
+        public ulong MaxLv;
+        public ulong MaxPv;
+        public ulong MetadataCopies;
+
+        public MetadataPhysicalVolumeSection[] PhysicalVolumes;
+        public MetadataLogicalVolumeSection[] LogicalVolumes;
+
+
+        internal void Parse(string head, TextReader data)
+        {
+            Name = head.Trim().TrimEnd('{').TrimEnd();
+            string line;
+            while ((line = Metadata.ReadLine(data)) != null)
+            {
+                if (line == String.Empty) continue;
+                if (line.Contains("="))
+                {
+                    var parameter = Metadata.ParseParameter(line);
+                    switch (parameter.Key.Trim().ToLowerInvariant())
+                    {
+                        case "id":
+                            Id = Metadata.ParseStringValue(parameter.Value);
+                            break;
+                        case "seqno":
+                            SequenceNumber = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        case "format":
+                            Format = Metadata.ParseStringValue(parameter.Value);
+                            break;
+                        case "status":
+                            var values = Metadata.ParseArrayValue(parameter.Value);
+                            foreach (var value in values)
+                            {
+                                switch (value.ToLowerInvariant().Trim())
+                                {
+                                    case "read":
+                                        Status |= VolumeGroupStatus.Read;
+                                        break;
+                                    case "write":
+                                        Status |= VolumeGroupStatus.Write;
+                                        break;
+                                    case "resizeable":
+                                        Status |= VolumeGroupStatus.Resizeable;
+                                        break;
+                                    default:
+                                        throw new ArgumentOutOfRangeException("status", "Unexpected status in volume group metadata");
+                                }
+                            }
+                            break;
+                        case "flags":
+                            Flags = Metadata.ParseArrayValue(parameter.Value);
+                            break;
+                        case "extent_size":
+                            ExtentSize = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        case "max_lv":
+                            MaxLv = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        case "max_pv":
+                            MaxPv = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        case "metadata_copies":
+                            MetadataCopies = Metadata.ParseNumericValue(parameter.Value);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(parameter.Key, "Unexpected parameter in volume group metadata");
+                    }
+                }
+                else if (line.EndsWith("{"))
+                {
+                    var sectionName = line.TrimEnd('{').TrimEnd().ToLowerInvariant();
+                    switch (sectionName)
+                    {
+                        case "physical_volumes":
+                            PhysicalVolumes = ParsePhysicalVolumeSection(data);
+                            break;
+                        case "logical_volumes":
+                            LogicalVolumes = ParseLogicalVolumeSection(data);
+
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException(sectionName, "Unexpected section in volume group metadata");
+                    }
+                }
+                else if (line.EndsWith("}"))
+                {
+                    break;
+                }
+            }
+        }
+
+        private MetadataLogicalVolumeSection[] ParseLogicalVolumeSection(TextReader data)
+        {
+            var result = new List<MetadataLogicalVolumeSection>();
+
+            string line;
+            while ((line = Metadata.ReadLine(data)) != null)
+            {
+                if (line == String.Empty) continue;
+                if (line.EndsWith("{"))
+                {
+                    var pv = new MetadataLogicalVolumeSection();
+                    pv.Parse(line, data);
+                    result.Add(pv);
+                }
+                else if (line.EndsWith("}"))
+                {
+                    break;
+                }
+            }
+            return result.ToArray();
+        }
+
+        private MetadataPhysicalVolumeSection[] ParsePhysicalVolumeSection(TextReader data)
+        {
+            var result = new List<MetadataPhysicalVolumeSection>();
+
+            string line;
+            while ((line = Metadata.ReadLine(data)) != null)
+            {
+                if (line == String.Empty) continue;
+                if (line.EndsWith("{"))
+                {
+                    var pv = new MetadataPhysicalVolumeSection();
+                    pv.Parse(line, data);
+                    result.Add(pv);
+                }
+                else if (line.EndsWith("}"))
+                {
+                    break;
+                }
+            }
+            return result.ToArray();
+        }
+    }
+
+    [Flags]
+    internal enum VolumeGroupStatus
+    {
+        None = 0x0,
+        Read = 0x1,
+        Write = 0x2,
+        Resizeable = 0x4,
+    }
+}

--- a/src/Lvm/PhysicalVolume.cs
+++ b/src/Lvm/PhysicalVolume.cs
@@ -22,7 +22,6 @@
 
 namespace DiscUtils.Lvm
 {
-    using System;
     using System.IO;
     using DiscUtils.Partitions;
 
@@ -33,6 +32,8 @@ namespace DiscUtils.Lvm
 
         public readonly PhysicalVolumeLabel PhysicalVolumeLabel;
         public readonly PvHeader PvHeader;
+        public readonly VolumeGroupMetadata VgMetadata;
+        public Stream Content { get; private set; }
 
         public PhysicalVolume(PhysicalVolumeLabel physicalVolumeLabel, Stream content)
         {
@@ -48,7 +49,10 @@ namespace DiscUtils.Lvm
                 content.Position = (long) area.Offset;
                 buffer = Utilities.ReadFully(content, (int) area.Length);
                 metadata.ReadFrom(buffer, 0x0);
+                VgMetadata = metadata;
             }
+
+            Content = content;
         }
 
         public static bool TryOpen(PartitionInfo volumeInfo, out PhysicalVolume pv)
@@ -64,7 +68,7 @@ namespace DiscUtils.Lvm
             if (!SearchLabel(content, out label)) return false;
             pv = new PhysicalVolume(label, content);
             
-            return false;
+            return true;
         }
 
         private static bool SearchLabel(Stream content, out PhysicalVolumeLabel pvLabel)

--- a/src/Lvm/PhysicalVolume.cs
+++ b/src/Lvm/PhysicalVolume.cs
@@ -1,0 +1,130 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+    using System.IO;
+    using DiscUtils.Partitions;
+
+    internal class PhysicalVolume
+    {
+        public const ushort SECTOR_SIZE = 512;
+        private const uint INITIAL_CRC = 0xf597a6cf;
+
+        public readonly PhysicalVolumeLabel PhysicalVolumeLabel;
+        public readonly PvHeader PvHeader;
+
+        public PhysicalVolume(PhysicalVolumeLabel physicalVolumeLabel, Stream content)
+        {
+            PhysicalVolumeLabel = physicalVolumeLabel;
+            PvHeader = new PvHeader();
+            content.Position = (long) (physicalVolumeLabel.Sector * SECTOR_SIZE);
+            var buffer = Utilities.ReadFully(content, SECTOR_SIZE);
+            PvHeader.ReadFrom(buffer, (int) physicalVolumeLabel.Offset);
+            if (PvHeader.MetadataDiskAreas.Length > 0)
+            {
+                var area = PvHeader.MetadataDiskAreas[0];
+                var metadata = new VolumeGroupMetadata();
+                content.Position = (long) area.Offset;
+                buffer = Utilities.ReadFully(content, (int) area.Length);
+                metadata.ReadFrom(buffer, 0x0);
+            }
+        }
+
+        public static bool TryOpen(PartitionInfo volumeInfo, out PhysicalVolume pv)
+        {
+            var content = volumeInfo.Open();
+            return TryOpen(content, out pv);
+        }
+
+        public static bool TryOpen(Stream content, out PhysicalVolume pv)
+        {
+            PhysicalVolumeLabel label;
+            pv = null;
+            if (!SearchLabel(content, out label)) return false;
+            pv = new PhysicalVolume(label, content);
+            
+            return false;
+        }
+
+        private static bool SearchLabel(Stream content, out PhysicalVolumeLabel pvLabel)
+        {
+            pvLabel = null;
+            content.Position = 0;
+            byte[] buffer = new byte[SECTOR_SIZE];
+            for (uint i = 0; i < 4; i++)
+            {
+                if (Utilities.ReadFully(content, buffer, 0, SECTOR_SIZE) != SECTOR_SIZE)
+                    return false;
+                var label = Utilities.BytesToString(buffer, 0x0, 0x8);
+                if (label == PhysicalVolumeLabel.LABEL_ID)
+                {
+                    pvLabel = new PhysicalVolumeLabel();
+                    pvLabel.ReadFrom(buffer, 0x0);
+                    if (pvLabel.Sector != i)
+                    {
+                        //Invalid PV Sector;
+                        return false;
+                    }
+                    if (pvLabel.Crc != pvLabel.CalculatedCrc)
+                    {
+                        //Invalid PV CRC
+                        return false;
+                    }
+                    if (pvLabel.Label2 != PhysicalVolumeLabel.LVM2_LABEL)
+                    {
+                        //Invalid LVM2 Label
+                        return false;
+                    }
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// LVM2.2.02.79:lib/misc/crc.c:_calc_crc_old()
+        /// </summary>
+        internal static uint CalcCrc(byte[] buffer, int offset, int length)
+        {
+            uint crc = INITIAL_CRC;
+            var crctab = new uint[]
+            {
+                0x00000000, 0x1db71064, 0x3b6e20c8, 0x26d930ac,
+                0x76dc4190, 0x6b6b51f4, 0x4db26158, 0x5005713c,
+                0xedb88320, 0xf00f9344, 0xd6d6a3e8, 0xcb61b38c,
+                0x9b64c2b0, 0x86d3d2d4, 0xa00ae278, 0xbdbdf21c
+            };
+            var i = offset;
+            while (i < offset + length)
+            {
+                crc ^= buffer[i];
+                crc = (crc >> 4) ^ crctab[crc & 0xf];
+                crc = (crc >> 4) ^ crctab[crc & 0xf];
+                i++;
+            }
+            return crc;
+
+        }
+    }
+}

--- a/src/Lvm/PhysicalVolumeLabel.cs
+++ b/src/Lvm/PhysicalVolumeLabel.cs
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+
+    internal class PhysicalVolumeLabel : IByteArraySerializable
+    {
+        public const string LABEL_ID = "LABELONE";
+        public const string LVM2_LABEL = "LVM2 001";
+
+        public string Label;
+        public ulong Sector;
+        public ulong Crc;
+        public ulong CalculatedCrc;
+        public ulong Offset;
+        public string Label2;
+        
+        /// <inheritdoc />
+        public int Size { get { return PhysicalVolume.SECTOR_SIZE; } }
+
+        /// <inheritdoc />
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Label = Utilities.BytesToString(buffer, offset, 0x8);
+            Sector = Utilities.ToUInt64LittleEndian(buffer, offset + 0x8);
+            Crc = Utilities.ToUInt32LittleEndian(buffer, offset + 0x10);
+            CalculatedCrc = PhysicalVolume.CalcCrc(buffer, offset + 0x14, PhysicalVolume.SECTOR_SIZE - 0x14);
+            Offset = Utilities.ToUInt32LittleEndian(buffer, offset + 0x14);
+            Label2 = Utilities.BytesToString(buffer, offset + 0x18, 0x8);
+            return Size;
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Lvm/PvHeader.cs
+++ b/src/Lvm/PvHeader.cs
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    internal class PvHeader : IByteArraySerializable
+    {
+        public string Uuid;
+        public ulong DeviceSize;
+        public DiskArea[] DiskAreas;
+        public DiskArea[] MetadataDiskAreas;
+        /// <inheritdoc />
+        public int Size { get { return PhysicalVolume.SECTOR_SIZE; } }
+
+        /// <inheritdoc />
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Uuid = ReadUuid(buffer, offset);
+            DeviceSize = Utilities.ToUInt64LittleEndian(buffer, offset + 0x20);
+            var areas = new List<DiskArea>();
+            var areaOffset = offset + 0x28;
+            while (true)
+            {
+                var area = new DiskArea();
+                areaOffset += area.ReadFrom(buffer, areaOffset);
+                if (area.Offset == 0 && area.Length == 0) break;
+                areas.Add(area);
+            }
+            DiskAreas = areas.ToArray();
+            areas = new List<DiskArea>();
+            while (true)
+            {
+                var area = new DiskArea();
+                areaOffset += area.ReadFrom(buffer, areaOffset);
+                if (area.Offset == 0 && area.Length == 0) break;
+                areas.Add(area);
+            }
+            MetadataDiskAreas = areas.ToArray();
+            return Size;
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static string ReadUuid(byte[] buffer, int offset)
+        {
+            var sb = new StringBuilder();
+            sb.Append(Utilities.BytesToString(buffer, offset, 0x6)).Append('-');
+            sb.Append(Utilities.BytesToString(buffer, offset + 0x6, 0x4)).Append('-');
+            sb.Append(Utilities.BytesToString(buffer, offset + 0xA, 0x4)).Append('-');
+            sb.Append(Utilities.BytesToString(buffer, offset + 0xE, 0x4)).Append('-');
+            sb.Append(Utilities.BytesToString(buffer, offset + 0x12, 0x4)).Append('-');
+            sb.Append(Utilities.BytesToString(buffer, offset + 0x16, 0x4)).Append('-');
+            sb.Append(Utilities.BytesToString(buffer, offset + 0x1A, 0x6));
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Lvm/RawLocationFlags.cs
+++ b/src/Lvm/RawLocationFlags.cs
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    [Flags]
+    internal enum RawLocationFlags : uint
+    {
+        /// <summary>
+        /// The raw location descriptor should be ignored
+        /// </summary>
+        Ignored = 0x00000001,
+
+        None = 0x00000000
+    }
+}

--- a/src/Lvm/RawLocations.cs
+++ b/src/Lvm/RawLocations.cs
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+
+    internal class RawLocation : IByteArraySerializable
+    {
+        public ulong Offset;
+        public ulong Length;
+        public uint Checksum;
+        public RawLocationFlags Flags;
+        
+        /// <inheritdoc />
+        public int Size { get { return 0x18; } }
+
+        /// <inheritdoc />
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Offset = Utilities.ToUInt64LittleEndian(buffer, offset);
+            Length = Utilities.ToUInt64LittleEndian(buffer, offset + 0x8);
+            Checksum = Utilities.ToUInt32LittleEndian(buffer, offset + 0x10);
+            Flags = (RawLocationFlags) Utilities.ToUInt32LittleEndian(buffer, offset + 0x14);
+            return Size;
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Lvm/VolumeGroupMetadata.cs
+++ b/src/Lvm/VolumeGroupMetadata.cs
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Lvm
+{
+    using System;
+    using System.Collections.Generic;
+
+    internal class VolumeGroupMetadata : IByteArraySerializable
+    {
+        public const string VgMetadataMagic = " LVM2 x[5A%r0N*>";
+        public const uint VgMetadataVersion = 1;
+        public uint Crc;
+        public ulong CalculatedCrc;
+        public string Magic;
+        public uint Version;
+        public ulong Start;
+        public ulong Length;
+        public RawLocation[] RawLocations;
+        public string Metadata;
+        public Metadata ParsedMetadata;
+
+        /// <inheritdoc />
+        public int Size { get { return (int) Length; } }
+
+        /// <inheritdoc />
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Crc = Utilities.ToUInt32LittleEndian(buffer, offset);
+            CalculatedCrc = PhysicalVolume.CalcCrc(buffer, offset + 0x4, PhysicalVolume.SECTOR_SIZE - 0x4);
+            Magic = Utilities.BytesToString(buffer, offset + 0x4, 0x10);
+            Version = Utilities.ToUInt32LittleEndian(buffer, offset + 0x14);
+            Start = Utilities.ToUInt64LittleEndian(buffer, offset + 0x18);
+            Length = Utilities.ToUInt64LittleEndian(buffer, offset + 0x20);
+
+            var locations = new List<RawLocation>();
+            var locationOffset = offset + 0x28;
+            while (true)
+            {
+                var location = new RawLocation();
+                locationOffset += location.ReadFrom(buffer, locationOffset);
+                if (location.Offset == 0 && location.Length == 0 && location.Checksum == 0 && location.Flags == 0) break;
+                locations.Add(location);
+            }
+            RawLocations = locations.ToArray();
+            foreach (var location in RawLocations)
+            {
+                if ((location.Flags & RawLocationFlags.Ignored) != 0)
+                    continue;
+                Metadata = Utilities.BytesToString(buffer, (int)location.Offset, (int)location.Length);
+                ParsedMetadata = Lvm.Metadata.Parse(Metadata);
+                break;
+            }
+            return Size;
+        }
+
+        /// <inheritdoc />
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Lvm/VolumeGroupMetadata.cs
+++ b/src/Lvm/VolumeGroupMetadata.cs
@@ -24,6 +24,7 @@ namespace DiscUtils.Lvm
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
 
     internal class VolumeGroupMetadata : IByteArraySerializable
     {
@@ -66,6 +67,9 @@ namespace DiscUtils.Lvm
             {
                 if ((location.Flags & RawLocationFlags.Ignored) != 0)
                     continue;
+                var checksum = PhysicalVolume.CalcCrc(buffer, (int) location.Offset, (int) location.Length);
+                if (location.Checksum != checksum)
+                    throw new IOException("invalid metadata checksum");
                 Metadata = Utilities.BytesToString(buffer, (int)location.Offset, (int)location.Length);
                 ParsedMetadata = Lvm.Metadata.Parse(Metadata);
                 break;

--- a/src/Utilities.cs
+++ b/src/Utilities.cs
@@ -564,10 +564,10 @@ namespace DiscUtils
         /// this preserves those code points by removing the top 16 bits of each character.</remarks>
         public static void StringToBytes(string value, byte[] dest, int offset, int count)
         {
-            char[] chars = value.ToCharArray();
+            char[] chars = value.ToCharArray(0, Math.Min(value.Length, count));
 
             int i = 0;
-            while (i < chars.Length)
+            while (i < chars.Length && i < count)
             {
                 dest[i + offset] = (byte)chars[i];
                 ++i;


### PR DESCRIPTION
I've added support for reading LVM striped volumes. While creating this PR I've found [another PR](https://discutils.codeplex.com/SourceControl/network/forks/phra/DiscUtilsLVM/contribution/8157), but this doesn't seem to be portable (using Reflection, Linq, etc.).

The code was verified against a vhdx containing a single PV, single VG, multiple LV's. The LV's where resized multiple times, so that they interleave. Write support is untested.

LVM Version: 2.02.98
Kernel: 3.13.0-98 64Bit