### PR TITLE
Readonly XFS Support

### DIFF
--- a/src/Xfs/AllocationGroup.cs
+++ b/src/Xfs/AllocationGroup.cs
@@ -35,9 +35,11 @@ namespace DiscUtils.Xfs
 
         public AllocationGroupInodeBtreeInfo InodeBtreeInfo { get; private set; }
 
-        public AllocationGroup(SuperBlock superblock, Stream data, long offset)
+        public AllocationGroup(Context context, long offset)
         {
             Offset = offset;
+            var data = context.RawStream;
+            var superblock = context.SuperBlock;
             FreeBlockInfo = new AllocationGroupFreeBlockInfo();
             data.Position = offset + superblock.SectorSize;
             var agfData = Utilities.ReadFully(data, FreeBlockInfo.Size); 
@@ -55,7 +57,7 @@ namespace DiscUtils.Xfs
             {
                 throw new IOException("Invalid AGI magic - probably not an xfs file system");
             }
-            InodeBtreeInfo.LoadBtree(data, superblock, offset);
+            InodeBtreeInfo.LoadBtree(context, offset);
             if (InodeBtreeInfo.RootInodeBtree.Magic != IbtMagic)
             {
                 throw new IOException("Invalid IBT magic - probably not an xfs file system");

--- a/src/Xfs/AllocationGroup.cs
+++ b/src/Xfs/AllocationGroup.cs
@@ -28,12 +28,16 @@ namespace DiscUtils.Xfs
 
     internal class AllocationGroup
     {
+        public const uint IbtMagic = 0x49414254;
+        public long Offset { get; private set; }
+
         public AllocationGroupFreeBlockInfo FreeBlockInfo { get; private set; }
 
         public AllocationGroupInodeBtreeInfo InodeBtreeInfo { get; private set; }
 
         public AllocationGroup(SuperBlock superblock, Stream data, long offset)
         {
+            Offset = offset;
             FreeBlockInfo = new AllocationGroupFreeBlockInfo();
             data.Position = offset + superblock.SectorSize;
             var agfData = Utilities.ReadFully(data, FreeBlockInfo.Size); 
@@ -50,6 +54,11 @@ namespace DiscUtils.Xfs
             if (InodeBtreeInfo.Magic != AllocationGroupInodeBtreeInfo.AgiMagic)
             {
                 throw new IOException("Invalid AGI magic - probably not an xfs file system");
+            }
+            InodeBtreeInfo.LoadBtree(data, superblock, offset);
+            if (InodeBtreeInfo.RootInodeBtree.Magic != IbtMagic)
+            {
+                throw new IOException("Invalid IBT magic - probably not an xfs file system");
             }
         }
     }

--- a/src/Xfs/AllocationGroupFreeBlockInfo.cs
+++ b/src/Xfs/AllocationGroupFreeBlockInfo.cs
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+
+    internal class AllocationGroupFreeBlockInfo : IByteArraySerializable
+    {
+        public const uint AgfMagic = 0x58414746;
+        /// <summary>
+        /// Specifies the magic number for the AGF sector: "XAGF" (0x58414746).
+        /// </summary>
+        public uint Magic;
+        
+        /// <summary>
+        /// Set to XFS_AGF_VERSION which is currently 1.
+        /// </summary>
+        public uint Version;
+
+        /// <summary>
+        /// Specifies the AG number for the sector.
+        /// </summary>
+        public uint SequenceNumber;
+
+        /// <summary>
+        /// Specifies the size of the AG in filesystem blocks. For all AGs except the last, this must be equal
+        /// to the superblock's <see cref="SuperBlock.AgBlocks"/> value. For the last AG, this could be less than the
+        /// <see cref="SuperBlock.AgBlocks"/> value. It is this value that should be used to determine the size of the AG.
+        /// </summary>
+        public uint Length;
+
+        /// <summary>
+        /// Specifies the block number for the root of the two free space B+trees.
+        /// </summary>
+        public uint[] RootBlockNumbers;
+        
+        public uint Spare0;
+
+        /// <summary>
+        /// Specifies the level or depth of the two free space B+trees. For a fresh AG, this will be one, and
+        /// the "roots" will point to a single leaf of level 0.
+        /// </summary>
+        public uint[] Levels;
+
+        public uint Spare1;
+
+        /// <summary>
+        /// Specifies the index of the first "free list" block.
+        /// </summary>
+        public uint FreeListFirst;
+
+        /// <summary>
+        /// Specifies the index of the last "free list" block.
+        /// </summary>
+        public uint FreeListLast;
+
+        /// <summary>
+        /// Specifies the number of blocks in the "free list".
+        /// </summary>
+        public uint FreeListCount;
+
+        /// <summary>
+        /// Specifies the current number of free blocks in the AG.
+        /// </summary>
+        public uint FreeBlocks;
+
+        /// <summary>
+        /// Specifies the number of blocks of longest contiguous free space in the AG.
+        /// </summary>
+        public uint Longest;
+
+        /// <summary>
+        /// Specifies the number of blocks used for the free space B+trees. This is only used if the
+        /// XFS_SB_VERSION2_LAZYSBCOUNTBIT bit is set in <see cref="SuperBlock.Features2"/>.
+        /// </summary>
+        public uint BTreeBlocks;
+
+        public int Size
+        {
+            get { return 0x40; }
+        }
+
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Magic = Utilities.ToUInt32BigEndian(buffer, offset);
+            Version = Utilities.ToUInt32BigEndian(buffer, offset + 0x4);
+            SequenceNumber = Utilities.ToUInt32BigEndian(buffer, offset + 0x8);
+            Length = Utilities.ToUInt32BigEndian(buffer, offset + 0xC);
+            RootBlockNumbers = new uint[2];
+            RootBlockNumbers[0] = Utilities.ToUInt32BigEndian(buffer, offset + 0x10);
+            RootBlockNumbers[1] = Utilities.ToUInt32BigEndian(buffer, offset + 0x14);
+            Spare0 = Utilities.ToUInt32BigEndian(buffer, offset + 0x18);
+            Levels = new uint[2];
+            Levels[0] = Utilities.ToUInt32BigEndian(buffer, offset + 0x1C);
+            Levels[1] = Utilities.ToUInt32BigEndian(buffer, offset + 0x20);
+            Spare1 = Utilities.ToUInt32BigEndian(buffer, offset + 0x24);
+            FreeListFirst = Utilities.ToUInt32BigEndian(buffer, offset + 0x28);
+            FreeListLast = Utilities.ToUInt32BigEndian(buffer, offset + 0x2C);
+            FreeListCount = Utilities.ToUInt32BigEndian(buffer, offset + 0x30);
+            FreeBlocks = Utilities.ToUInt32BigEndian(buffer, offset + 0x34);
+            Longest = Utilities.ToUInt32BigEndian(buffer, offset + 0x38);
+            BTreeBlocks = Utilities.ToUInt32BigEndian(buffer, offset + 0x3C);
+            return Size;
+        }
+
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xfs/AllocationGroupFreeBlockInfo.cs
+++ b/src/Xfs/AllocationGroupFreeBlockInfo.cs
@@ -27,34 +27,36 @@ namespace DiscUtils.Xfs
     internal class AllocationGroupFreeBlockInfo : IByteArraySerializable
     {
         public const uint AgfMagic = 0x58414746;
+        public const uint BtreeMagicOffset = 0x41425442;
+        public const uint BtreeMagicCount = 0x41425443;
         /// <summary>
         /// Specifies the magic number for the AGF sector: "XAGF" (0x58414746).
         /// </summary>
-        public uint Magic;
-        
+        public uint Magic { get; private set; }
+
         /// <summary>
         /// Set to XFS_AGF_VERSION which is currently 1.
         /// </summary>
-        public uint Version;
+        public uint Version { get; private set; }
 
         /// <summary>
         /// Specifies the AG number for the sector.
         /// </summary>
-        public uint SequenceNumber;
+        public uint SequenceNumber { get; private set; }
 
         /// <summary>
         /// Specifies the size of the AG in filesystem blocks. For all AGs except the last, this must be equal
         /// to the superblock's <see cref="SuperBlock.AgBlocks"/> value. For the last AG, this could be less than the
         /// <see cref="SuperBlock.AgBlocks"/> value. It is this value that should be used to determine the size of the AG.
         /// </summary>
-        public uint Length;
+        public uint Length { get; private set; }
 
         /// <summary>
         /// Specifies the block number for the root of the two free space B+trees.
         /// </summary>
-        public uint[] RootBlockNumbers;
-        
-        public uint Spare0;
+        public uint[] RootBlockNumbers { get; private set; }
+
+        public uint Spare0 { get; private set; }
 
         /// <summary>
         /// Specifies the level or depth of the two free space B+trees. For a fresh AG, this will be one, and
@@ -62,38 +64,48 @@ namespace DiscUtils.Xfs
         /// </summary>
         public uint[] Levels;
 
-        public uint Spare1;
+        public uint Spare1 { get; private set; }
 
         /// <summary>
         /// Specifies the index of the first "free list" block.
         /// </summary>
-        public uint FreeListFirst;
+        public uint FreeListFirst { get; private set; }
 
         /// <summary>
         /// Specifies the index of the last "free list" block.
         /// </summary>
-        public uint FreeListLast;
+        public uint FreeListLast { get; private set; }
 
         /// <summary>
         /// Specifies the number of blocks in the "free list".
         /// </summary>
-        public uint FreeListCount;
+        public uint FreeListCount { get; private set; }
 
         /// <summary>
         /// Specifies the current number of free blocks in the AG.
         /// </summary>
-        public uint FreeBlocks;
+        public uint FreeBlocks { get; private set; }
 
         /// <summary>
         /// Specifies the number of blocks of longest contiguous free space in the AG.
         /// </summary>
-        public uint Longest;
+        public uint Longest { get; private set; }
 
         /// <summary>
         /// Specifies the number of blocks used for the free space B+trees. This is only used if the
         /// XFS_SB_VERSION2_LAZYSBCOUNTBIT bit is set in <see cref="SuperBlock.Features2"/>.
         /// </summary>
-        public uint BTreeBlocks;
+        public uint BTreeBlocks { get; private set; }
+
+        /// <summary>
+        /// stores a sorted array of block offset and block counts in the leaves of the B+tree, sorted by the offset
+        /// </summary>
+        public BtreeHeader FreeSpaceOffset { get; private set; }
+
+        /// <summary>
+        /// stores a sorted array of block offset and block counts in the leaves of the B+tree, sorted by the count or size
+        /// </summary>
+        public BtreeHeader FreeSpaceCount { get; private set; }
 
         public int Size
         {

--- a/src/Xfs/AllocationGroupInodeBtreeInfo.cs
+++ b/src/Xfs/AllocationGroupInodeBtreeInfo.cs
@@ -127,7 +127,7 @@ namespace DiscUtils.Xfs
             {
                 RootInodeBtree = new BTreeInodeNode();
             }
-            var buffer = Utilities.ReadFully(data, RootInodeBtree.Size);
+            var buffer = Utilities.ReadFully(data, (int) context.SuperBlock.Blocksize);
             RootInodeBtree.ReadFrom(buffer, 0);
         }
 

--- a/src/Xfs/AllocationGroupInodeBtreeInfo.cs
+++ b/src/Xfs/AllocationGroupInodeBtreeInfo.cs
@@ -1,0 +1,117 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+
+    internal class AllocationGroupInodeBtreeInfo : IByteArraySerializable
+    {
+        public const uint AgiMagic = 0x58414749;
+
+        /// <summary>
+        /// Specifies the magic number for the AGI sector: "XAGI" (0x58414749)
+        /// </summary>
+        public uint Magic { get; private set; }
+
+        /// <summary>
+        /// Set to XFS_AGI_VERSION which is currently 1.
+        /// </summary>
+        public uint Version { get; private set; }
+
+        /// <summary>
+        /// Specifies the AG number for the sector.
+        /// </summary>
+        public uint SequenceNumber { get; private set; }
+
+        /// <summary>
+        /// Specifies the size of the AG in filesystem blocks.
+        /// </summary>
+        public uint Length { get; private set; }
+
+        /// <summary>
+        /// Specifies the number of inodes allocated for the AG.
+        /// </summary>
+        public uint Count { get; private set; }
+
+        /// <summary>
+        /// Specifies the block number in the AG containing the root of the inode B+tree.
+        /// </summary>
+        public uint Root { get; private set; }
+
+        /// <summary>
+        /// Specifies the number of levels in the inode B+tree.
+        /// </summary>
+        public uint Level { get; private set; }
+
+        /// <summary>
+        /// Specifies the number of free inodes in the AG.
+        /// </summary>
+        public uint FreeCount { get; private set; }
+
+        /// <summary>
+        /// Specifies AG relative inode number most recently allocated.
+        /// </summary>
+        public uint NewInode { get; private set; }
+
+        /// <summary>
+        /// Deprecated and not used, it's always set to NULL (-1).
+        /// </summary>
+        [Obsolete]
+        public int DirInode { get; private set; }
+
+        /// <summary>
+        /// Hash table of unlinked (deleted) inodes that are still being referenced.
+        /// </summary>
+        public int[] Unlinked { get; private set; }
+
+        public int Size
+        {
+            get { return 296; }
+        }
+
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Magic = Utilities.ToUInt32BigEndian(buffer, offset);
+            Version = Utilities.ToUInt32BigEndian(buffer, offset + 0x4);
+            SequenceNumber = Utilities.ToUInt32BigEndian(buffer, offset + 0x8);
+            Length = Utilities.ToUInt32BigEndian(buffer, offset + 0xc);
+            Count = Utilities.ToUInt32BigEndian(buffer, offset + 0x10);
+            Root = Utilities.ToUInt32BigEndian(buffer, offset + 0x14);
+            Level = Utilities.ToUInt32BigEndian(buffer, offset + 0x18);
+            FreeCount = Utilities.ToUInt32BigEndian(buffer, offset + 0x1c);
+            NewInode = Utilities.ToUInt32BigEndian(buffer, offset + 0x20);
+            DirInode = Utilities.ToInt32BigEndian(buffer, offset + 0x24);
+            Unlinked = new int[64];
+            for (int i = 0; i < Unlinked.Length; i++)
+            {
+                Unlinked[i] = Utilities.ToInt32BigEndian(buffer, offset + 0x28 + i*0x4);
+            }
+            return Size;
+        }
+
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xfs/AllocationGroupInodeBtreeInfo.cs
+++ b/src/Xfs/AllocationGroupInodeBtreeInfo.cs
@@ -23,6 +23,7 @@
 namespace DiscUtils.Xfs
 {
     using System;
+    using System.IO;
 
     internal class AllocationGroupInodeBtreeInfo : IByteArraySerializable
     {
@@ -84,6 +85,11 @@ namespace DiscUtils.Xfs
         /// </summary>
         public int[] Unlinked { get; private set; }
 
+        /// <summary>
+        /// root of the inode B+tree
+        /// </summary>
+        public BtreeHeader RootInodeBtree { get; private set; }
+
         public int Size
         {
             get { return 296; }
@@ -107,6 +113,14 @@ namespace DiscUtils.Xfs
                 Unlinked[i] = Utilities.ToInt32BigEndian(buffer, offset + 0x28 + i*0x4);
             }
             return Size;
+        }
+
+        public void LoadBtree(Stream data, SuperBlock superBlock, long offset)
+        {
+            data.Position = offset + superBlock.Blocksize*Root;
+            RootInodeBtree = new BtreeHeader();
+            var buffer = Utilities.ReadFully(data, RootInodeBtree.Size);
+            RootInodeBtree.ReadFrom(buffer, 0);
         }
 
         public void WriteTo(byte[] buffer, int offset)

--- a/src/Xfs/AllocationGroupInodeBtreeInfo.cs
+++ b/src/Xfs/AllocationGroupInodeBtreeInfo.cs
@@ -115,10 +115,18 @@ namespace DiscUtils.Xfs
             return Size;
         }
 
-        public void LoadBtree(Stream data, SuperBlock superBlock, long offset)
+        public void LoadBtree(Context context, long offset)
         {
-            data.Position = offset + superBlock.Blocksize*Root;
-            RootInodeBtree = new BtreeHeader();
+            var data = context.RawStream;
+            data.Position = offset + context.SuperBlock.Blocksize*Root;
+            if (Level == 1)
+            {
+                RootInodeBtree = new BTreeInodeLeave();
+            }
+            else
+            {
+                RootInodeBtree = new BTreeInodeNode();
+            }
             var buffer = Utilities.ReadFully(data, RootInodeBtree.Size);
             RootInodeBtree.ReadFrom(buffer, 0);
         }

--- a/src/Xfs/BTreeExtentHeader.cs
+++ b/src/Xfs/BTreeExtentHeader.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) 2016, Bianco Veigel
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -23,33 +23,44 @@
 namespace DiscUtils.Xfs
 {
     using System;
-    using System.Text;
+    using System.Collections.Generic;
 
-    /// <summary>
-    /// XFS file system options.
-    /// </summary>
-    public sealed class XfsFileSystemOptions : DiscFileSystemOptions
+    internal abstract class BTreeExtentHeader : IByteArraySerializable
     {
-        internal XfsFileSystemOptions()
+        public const uint BtreeMagic = 0x424d4150;
+
+        public uint Magic { get; private set; }
+
+        public ushort Level { get; protected set; }
+
+        public ushort NumberOfRecords { get; protected set; }
+
+        public long LeftSibling { get; private set; }
+
+        public long RightSibling { get; private set; }
+
+        public virtual int Size
         {
-            FileNameEncoding = Encoding.UTF8;
+            get { return 24; }
         }
 
-        internal XfsFileSystemOptions(FileSystemParameters parameters)
+        public virtual int ReadFrom(byte[] buffer, int offset)
         {
-            if (parameters != null && parameters.FileNameEncoding != null)
-            {
-                FileNameEncoding = parameters.FileNameEncoding;
-            }
-            else
-            {
-                FileNameEncoding = Encoding.UTF8;
-            }
+            Magic = Utilities.ToUInt32BigEndian(buffer, offset);
+            Level = Utilities.ToUInt16BigEndian(buffer, offset + 0x4);
+            NumberOfRecords = Utilities.ToUInt16BigEndian(buffer, offset + 0x6);
+            LeftSibling = Utilities.ToInt64BigEndian(buffer, offset + 0x8);
+            RightSibling = Utilities.ToInt64BigEndian(buffer, offset + 0xC);
+            return 24;
         }
 
-        /// <summary>
-        /// Gets or sets the character encoding used for file names.
-        /// </summary>
-        public Encoding FileNameEncoding { get; set; }
+        public virtual void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+
+        public abstract void LoadBtree(Context context);
+
+        public abstract IList<Extent> GetExtents();
     }
 }

--- a/src/Xfs/BTreeExtentNode.cs
+++ b/src/Xfs/BTreeExtentNode.cs
@@ -1,0 +1,99 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+    internal class BTreeExtentNode : BTreeExtentHeader
+    {
+        public ulong[] Keys { get; protected set; }
+
+        public ulong[] Pointer { get; protected set; }
+
+        public Dictionary<ulong, BTreeExtentHeader> Children { get; protected set; }
+
+        public override int Size
+        {
+            get { return base.Size + (NumberOfRecords * 0x8); }
+        }
+
+        public override int ReadFrom(byte[] buffer, int offset)
+        {
+            offset += base.ReadFrom(buffer, offset);
+            if (Level == 0)
+                throw new IOException("invalid B+tree level - expected >= 1");
+            Keys = new ulong[NumberOfRecords];
+            Pointer = new ulong[NumberOfRecords];
+            for (int i = 0; i < NumberOfRecords; i++)
+            {
+                Keys[i] = Utilities.ToUInt64BigEndian(buffer, offset + i * 0x8);
+            }
+            offset += ((buffer.Length - offset) / 16) * 8;
+            for (int i = 0; i < NumberOfRecords; i++)
+            {
+                Pointer[i] = Utilities.ToUInt64BigEndian(buffer, offset + i * 0x8);
+            }
+            return Size;
+        }
+
+        public override void LoadBtree(Context context)
+        {
+            Children = new Dictionary<ulong, BTreeExtentHeader>(NumberOfRecords);
+            for (int i = 0; i < NumberOfRecords; i++)
+            {
+                BTreeExtentHeader child;
+                if (Level == 1)
+                {
+                    child = new BTreeExtentLeave();
+                }
+                else
+                {
+                    child = new BTreeExtentNode();
+                }
+                var data = context.RawStream;
+                data.Position = Extent.GetOffset(context, Pointer[i]);
+                var buffer = Utilities.ReadFully(data, (int)context.SuperBlock.Blocksize);
+                child.ReadFrom(buffer, 0);
+                if (child.Magic != BtreeMagic)
+                {
+                    throw new IOException("invalid btree directory magic");
+                }
+                child.LoadBtree(context);
+                Children.Add(Keys[i], child);
+            }
+        }
+
+        /// <inheritdoc />
+        public override IList<Extent> GetExtents()
+        {
+            var result = new List<Extent>();
+            foreach (var child in Children)
+            {
+                result.AddRange(child.Value.GetExtents());
+            }
+            return result;
+        }
+    }
+}

--- a/src/Xfs/BTreeExtentRoot.cs
+++ b/src/Xfs/BTreeExtentRoot.cs
@@ -1,0 +1,110 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+    internal class BTreeExtentRoot : IByteArraySerializable
+    {
+        public ushort Level { get; protected set; }
+
+        public ushort NumberOfRecords { get; protected set; }
+
+        public ulong[] Keys { get; private set; }
+
+        public ulong[] Pointer { get; private set; }
+
+        public Dictionary<ulong, BTreeExtentHeader> Children { get; private set; }
+
+        public int Size
+        {
+            get { return 4 + (0x9 * 0x16); }
+        }
+
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Level = Utilities.ToUInt16BigEndian(buffer, offset);
+            NumberOfRecords = Utilities.ToUInt16BigEndian(buffer, offset + 0x2);
+            offset += 0x4;
+            Keys = new ulong[NumberOfRecords];
+            Pointer = new ulong[NumberOfRecords];
+            for (int i = 0; i < NumberOfRecords; i++)
+            {
+                Keys[i] = Utilities.ToUInt64BigEndian(buffer, offset + i * 0x8);
+            }
+            offset += ((buffer.Length - offset)/16)*8;
+            for (int i = 0; i < NumberOfRecords; i++)
+            {
+                Pointer[i] = Utilities.ToUInt64BigEndian(buffer, offset + i * 0x8);
+            }
+            return Size;
+        }
+
+
+        /// <inheritdoc />
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void LoadBtree(Context context)
+        {
+            Children = new Dictionary<ulong, BTreeExtentHeader>(NumberOfRecords);
+            for (int i = 0; i < NumberOfRecords; i++)
+            {
+                BTreeExtentHeader child;
+                if (Level == 1)
+                {
+                    child = new BTreeExtentLeave();
+                }
+                else
+                {
+                    child = new BTreeExtentNode();
+                }
+                var data = context.RawStream;
+                data.Position = Extent.GetOffset(context, Pointer[i]);
+                var buffer = Utilities.ReadFully(data, (int)context.SuperBlock.Blocksize);
+                child.ReadFrom(buffer, 0);
+                if (child.Magic != BTreeExtentHeader.BtreeMagic)
+                {
+                    throw new IOException("invalid btree directory magic");
+                }
+                child.LoadBtree(context);
+                Children.Add(Keys[i], child);
+            }
+        }
+
+        public List<Extent> GetExtents()
+        {
+            var result = new List<Extent>();
+            foreach (var child in Children)
+            {
+                result.AddRange(child.Value.GetExtents());
+            }
+            return result;
+        }
+    }
+}

--- a/src/Xfs/BTreeHeader.cs
+++ b/src/Xfs/BTreeHeader.cs
@@ -24,7 +24,7 @@ namespace DiscUtils.Xfs
 {
     using System;
 
-    internal class BtreeHeader : IByteArraySerializable
+    internal abstract class BtreeHeader : IByteArraySerializable
     {
         public uint Magic { get; private set; }
 
@@ -36,12 +36,12 @@ namespace DiscUtils.Xfs
 
         public int RightSibling { get; private set; }
 
-        public int Size
+        public virtual int Size
         {
             get { return 16; }
         }
 
-        public int ReadFrom(byte[] buffer, int offset)
+        public virtual int ReadFrom(byte[] buffer, int offset)
         {
             Magic = Utilities.ToUInt32BigEndian(buffer, offset);
             Level = Utilities.ToUInt16BigEndian(buffer, offset + 0x4);
@@ -51,9 +51,11 @@ namespace DiscUtils.Xfs
             return Size;
         }
 
-        public void WriteTo(byte[] buffer, int offset)
+        public virtual void WriteTo(byte[] buffer, int offset)
         {
             throw new NotImplementedException();
         }
+
+        public abstract void LoadBtree(Context context);
     }
 }

--- a/src/Xfs/BTreeHeader.cs
+++ b/src/Xfs/BTreeHeader.cs
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+
+    internal class BtreeHeader : IByteArraySerializable
+    {
+        public uint Magic { get; private set; }
+
+        public ushort Level { get; private set; }
+
+        public ushort NumberOfRecords { get; private set; }
+
+        public int LeftSibling { get; private set; }
+
+        public int RightSibling { get; private set; }
+
+        public int Size
+        {
+            get { return 16; }
+        }
+
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Magic = Utilities.ToUInt32BigEndian(buffer, offset);
+            Level = Utilities.ToUInt16BigEndian(buffer, offset + 0x4);
+            NumberOfRecords = Utilities.ToUInt16BigEndian(buffer, offset + 0x6);
+            LeftSibling = Utilities.ToInt32BigEndian(buffer, offset + 0x8);
+            RightSibling = Utilities.ToInt32BigEndian(buffer, offset + 0xC);
+            return Size;
+        }
+
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xfs/BTreeInodeLeave.cs
+++ b/src/Xfs/BTreeInodeLeave.cs
@@ -49,7 +49,7 @@ namespace DiscUtils.Xfs
             return Size;
         }
 
-        public override void LoadBtree(Context context)
+        public override void LoadBtree(AllocationGroup ag)
         {
             
         }

--- a/src/Xfs/BTreeInodeLeave.cs
+++ b/src/Xfs/BTreeInodeLeave.cs
@@ -1,0 +1,57 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System.IO;
+
+namespace DiscUtils.Xfs
+{
+    using System;
+
+    internal class BTreeInodeLeave : BtreeHeader
+    {
+        public BTreeInodeRecord[] Records { get; private set; }
+        public override int Size
+        {
+            get { return base.Size + (NumberOfRecords * 0x10); }
+        }
+
+        public override int ReadFrom(byte[] buffer, int offset)
+        {
+            offset += base.ReadFrom(buffer, offset);
+            if (Level != 0)
+                throw new IOException("invalid B+tree level - expected 1");
+            Records = new BTreeInodeRecord[NumberOfRecords];
+            for (int i = 0; i < NumberOfRecords; i++)
+            {
+                var rec = new BTreeInodeRecord();
+                offset += rec.ReadFrom(buffer, offset);
+                Records[i] = rec;
+            }
+            return Size;
+        }
+
+        public override void LoadBtree(Context context)
+        {
+            
+        }
+    }
+}

--- a/src/Xfs/BTreeInodeNode.cs
+++ b/src/Xfs/BTreeInodeNode.cs
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace DiscUtils.Xfs
+{
+    using System;
+
+    internal class BTreeInodeNode : BtreeHeader
+    {
+        public uint[] Keys { get; private set; }
+
+        public uint[] Pointer { get; private set; }
+
+        public Dictionary<uint, BtreeHeader> Children { get; private set; }
+
+        public override int Size
+        {
+            get { return base.Size + (NumberOfRecords * 0x8); }
+        }
+
+        public override int ReadFrom(byte[] buffer, int offset)
+        {
+            offset += base.ReadFrom(buffer, offset);
+            if (Level == 0)
+                throw new IOException("invalid B+tree level - expected 0");
+            Keys = new uint[NumberOfRecords];
+            Pointer = new uint[NumberOfRecords];
+            for (int i = 0; i < NumberOfRecords; i++)
+            {
+                Keys[i] = Utilities.ToUInt32BigEndian(buffer, offset);
+            }
+            for (int i = 0; i < NumberOfRecords; i++)
+            {
+                Pointer[i] = Utilities.ToUInt32BigEndian(buffer, offset);
+            }
+            return Size;
+        }
+
+        public override void LoadBtree(Context context)
+        {
+            Children = new Dictionary<uint,BtreeHeader>(NumberOfRecords);
+            for (int i = 0; i < NumberOfRecords; i++)
+            {
+                BtreeHeader child;
+                if (Level == 1)
+                {
+                    child = new BTreeInodeLeave();
+                }
+                else
+                {
+                    child = new BTreeInodeNode();
+                }
+                var data = context.RawStream;
+                data.Position = (Pointer[i] * context.SuperBlock.Blocksize) + agoffset;
+                var buffer = Utilities.ReadFully(data, (int) context.SuperBlock.Blocksize);
+                child.ReadFrom(buffer, 0);
+                child.LoadBtree(context);
+                Children.Add(Keys[i], child);
+            }
+        }
+    }
+}

--- a/src/Xfs/BTreeInodeNode.cs
+++ b/src/Xfs/BTreeInodeNode.cs
@@ -58,7 +58,7 @@ namespace DiscUtils.Xfs
             return Size;
         }
 
-        public override void LoadBtree(Context context)
+        public override void LoadBtree(AllocationGroup ag)
         {
             Children = new Dictionary<uint,BtreeHeader>(NumberOfRecords);
             for (int i = 0; i < NumberOfRecords; i++)
@@ -72,11 +72,11 @@ namespace DiscUtils.Xfs
                 {
                     child = new BTreeInodeNode();
                 }
-                var data = context.RawStream;
-                data.Position = (Pointer[i] * context.SuperBlock.Blocksize) + agoffset;
-                var buffer = Utilities.ReadFully(data, (int) context.SuperBlock.Blocksize);
+                var data = ag.Context.RawStream;
+                data.Position = (Pointer[i] * ag.Context.SuperBlock.Blocksize) + ag.Offset;
+                var buffer = Utilities.ReadFully(data, (int)ag.Context.SuperBlock.Blocksize);
                 child.ReadFrom(buffer, 0);
-                child.LoadBtree(context);
+                child.LoadBtree(ag);
                 Children.Add(Keys[i], child);
             }
         }

--- a/src/Xfs/BTreeInodeRecord.cs
+++ b/src/Xfs/BTreeInodeRecord.cs
@@ -1,0 +1,63 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System.Collections;
+
+namespace DiscUtils.Xfs
+{
+    using System;
+
+    internal class BTreeInodeRecord: IByteArraySerializable
+    {
+        /// <summary>
+        /// specifies the starting inode number for the chunk
+        /// </summary>
+        public uint StartInode { get; private set; }
+
+        /// <summary>
+        /// specifies the number of free entries in the chuck
+        /// </summary>
+        public uint FreeCount { get; private set; }
+
+        /// <summary>
+        /// 64 element bit array specifying which entries are free in the chunk
+        /// </summary>
+        public BitArray Free { get; private set; }
+        public int Size
+        {
+            get { return 0x10; }
+        }
+
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            StartInode = Utilities.ToUInt32BigEndian(buffer, offset);
+            FreeCount = Utilities.ToUInt32BigEndian(buffer, offset + 0x4);
+            Free = new BitArray(Utilities.ToByteArray(buffer, offset + 0x8, 0x8));
+            return Size;
+        }
+
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xfs/BlockDirectory.cs
+++ b/src/Xfs/BlockDirectory.cs
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.IO;
+    using System.Collections.Generic;
+
+    internal class BlockDirectory : IByteArraySerializable
+    {
+        public const uint HeaderMagic = 0x58443242;
+
+        public uint Magic { get; private set; }
+
+        public uint LeafCount { get; private set; }
+
+        public uint LeafStale { get; private set; }
+
+        public BlockDirectoryDataFree[] BestFree { get; private set; }
+
+        public BlockDirectoryData[] Entries { get; private set; }
+
+        public int Size
+        {
+            get { return 16 + 3*32; }
+        }
+
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Magic = Utilities.ToUInt32BigEndian(buffer, offset);
+            BestFree = new BlockDirectoryDataFree[3];
+            offset += 0x2;
+            for (int i = 0; i < BestFree.Length; i++)
+            {
+                var free = new BlockDirectoryDataFree();
+                offset += free.ReadFrom(buffer, offset);
+                BestFree[i] = free;
+            }
+
+            LeafStale = Utilities.ToUInt32BigEndian(buffer, buffer.Length - 0x4);
+            LeafCount = Utilities.ToUInt32BigEndian(buffer, buffer.Length - 0x8);
+            var entries = new List<BlockDirectoryData>();
+            var eof = buffer.Length - 0x8 - LeafCount*0x8;
+            while (offset < eof)
+            {
+                BlockDirectoryData entry;
+                if (buffer[offset] == 0xff && buffer[offset + 0x1] == 0xff)
+                {
+                    //unused
+                    entry = new BlockDirectoryDataUnused();
+                }
+                else
+                {
+                    entry = new BlockDirectoryDataEntry();
+                }
+                offset += entry.ReadFrom(buffer, offset);
+                entries.Add(entry);
+            }
+            Entries = entries.ToArray();
+            return buffer.Length - offset;
+        }
+
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xfs/BlockDirectoryData.cs
+++ b/src/Xfs/BlockDirectoryData.cs
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.IO;
+
+    internal abstract class BlockDirectoryData : IByteArraySerializable
+    {
+        public abstract int Size { get; }
+
+        public abstract int ReadFrom(byte[] buffer, int offset);
+
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xfs/BlockDirectoryDataEntry.cs
+++ b/src/Xfs/BlockDirectoryDataEntry.cs
@@ -22,9 +22,6 @@
 
 namespace DiscUtils.Xfs
 {
-    using System;
-    using System.IO;
-
     internal class BlockDirectoryDataEntry : BlockDirectoryData, IDirectoryEntry
     {
         public ulong Inode { get; private set; }
@@ -56,11 +53,6 @@ namespace DiscUtils.Xfs
             offset += padding;
             Tag = Utilities.ToUInt16BigEndian(buffer, offset + 0x9 + NameLength);
             return Size;
-        }
-
-        public void WriteTo(byte[] buffer, int offset)
-        {
-            throw new NotImplementedException();
         }
 
         /// <inheritdoc />

--- a/src/Xfs/BlockDirectoryDataEntry.cs
+++ b/src/Xfs/BlockDirectoryDataEntry.cs
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.IO;
+
+    internal class BlockDirectoryDataEntry : BlockDirectoryData
+    {
+        public ulong Inode { get; private set; }
+
+        public byte NameLength { get; private set; }
+
+        public string Name { get; private set; }
+
+        public ushort Tag { get; private set; }
+
+        public override int Size { get { return 0xb + NameLength; } }
+
+        public override int ReadFrom(byte[] buffer, int offset)
+        {
+            Inode = Utilities.ToUInt64BigEndian(buffer, offset);
+            NameLength = buffer[offset + 0x8];
+            Name = Utilities.BytesToString(buffer, offset + 0x9, NameLength);
+            Tag = Utilities.ToUInt16BigEndian(buffer, offset + 0x9 + NameLength);
+            return Size;
+        }
+
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xfs/BlockDirectoryDataFree.cs
+++ b/src/Xfs/BlockDirectoryDataFree.cs
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.IO;
+
+    internal class BlockDirectoryDataFree : IByteArraySerializable
+    {
+        public ushort Offset { get; private set; }
+
+        public ushort Length { get; private set; }
+
+        public int Size
+        {
+            get { return 32; }
+        }
+
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Offset = Utilities.ToUInt16BigEndian(buffer, offset);
+            Length = Utilities.ToUInt16BigEndian(buffer, offset + 0x2);
+            return Size;
+        }
+
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xfs/BlockDirectoryDataFree.cs
+++ b/src/Xfs/BlockDirectoryDataFree.cs
@@ -33,7 +33,7 @@ namespace DiscUtils.Xfs
 
         public int Size
         {
-            get { return 32; }
+            get { return 0x4; }
         }
 
         public int ReadFrom(byte[] buffer, int offset)

--- a/src/Xfs/BlockDirectoryDataUnused.cs
+++ b/src/Xfs/BlockDirectoryDataUnused.cs
@@ -22,9 +22,6 @@
 
 namespace DiscUtils.Xfs
 {
-    using System;
-    using System.IO;
-
     internal class BlockDirectoryDataUnused : BlockDirectoryData
     {
         public ushort Freetag { get; private set; }
@@ -41,11 +38,6 @@ namespace DiscUtils.Xfs
             Length = Utilities.ToUInt16BigEndian(buffer, offset + 0x2);
             Tag = Utilities.ToUInt16BigEndian(buffer, offset + Length - 0x2);
             return Size;
-        }
-
-        public void WriteTo(byte[] buffer, int offset)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/Xfs/BlockDirectoryDataUnused.cs
+++ b/src/Xfs/BlockDirectoryDataUnused.cs
@@ -1,0 +1,51 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.IO;
+
+    internal class BlockDirectoryDataUnused : BlockDirectoryData
+    {
+        public ushort Freetag { get; private set; }
+
+        public ushort Length { get; private set; }
+
+        public ushort Tag { get; private set; }
+
+        public override int Size { get { return Length + 0x2; } }
+
+        public override int ReadFrom(byte[] buffer, int offset)
+        {
+            Freetag = Utilities.ToUInt16BigEndian(buffer, offset);
+            Length = Utilities.ToUInt16BigEndian(buffer, offset + 0x2);
+            Tag = Utilities.ToUInt16BigEndian(buffer, offset + Length);
+            return Size;
+        }
+
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xfs/BlockDirectoryDataUnused.cs
+++ b/src/Xfs/BlockDirectoryDataUnused.cs
@@ -33,13 +33,13 @@ namespace DiscUtils.Xfs
 
         public ushort Tag { get; private set; }
 
-        public override int Size { get { return Length + 0x2; } }
+        public override int Size { get { return Length; } }
 
         public override int ReadFrom(byte[] buffer, int offset)
         {
             Freetag = Utilities.ToUInt16BigEndian(buffer, offset);
             Length = Utilities.ToUInt16BigEndian(buffer, offset + 0x2);
-            Tag = Utilities.ToUInt16BigEndian(buffer, offset + Length);
+            Tag = Utilities.ToUInt16BigEndian(buffer, offset + Length - 0x2);
             return Size;
         }
 

--- a/src/Xfs/Context.cs
+++ b/src/Xfs/Context.cs
@@ -31,5 +31,17 @@ namespace DiscUtils.Xfs
         public Stream RawStream { get; set; }
 
         public SuperBlock SuperBlock { get; set; }
+
+        public AllocationGroup[] AllocationGroups { get; set; }
+
+        public Inode GetInode(ulong number)
+        {
+            var inode = new Inode(number, this);
+            AllocationGroup group = AllocationGroups[inode.AllocationGroup];
+            group.LoadInode(inode);
+            if (inode.Magic != Inode.InodeMagic)
+                throw new IOException("invalid inode magic");
+            return inode;
+        }
     }
 }

--- a/src/Xfs/Context.cs
+++ b/src/Xfs/Context.cs
@@ -33,6 +33,8 @@ namespace DiscUtils.Xfs
         public SuperBlock SuperBlock { get; set; }
 
         public AllocationGroup[] AllocationGroups { get; set; }
+        
+        public XfsFileSystemOptions Options { get; set; }
 
         public Inode GetInode(ulong number)
         {

--- a/src/Xfs/Context.cs
+++ b/src/Xfs/Context.cs
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System.IO;
+    using DiscUtils.Vfs;
+
+    internal class Context : VfsContext
+    {
+        public Stream RawStream { get; set; }
+
+        public SuperBlock SuperBlock { get; set; }
+    }
+}

--- a/src/Xfs/DirEntry.cs
+++ b/src/Xfs/DirEntry.cs
@@ -29,16 +29,23 @@ namespace DiscUtils.Xfs
 
     internal class DirEntry : VfsDirEntry
     {
-        private readonly ShortformDirectoryEntry _entry;
+        private readonly IDirectoryEntry _entry;
         private readonly Context _context;
+        private string _name;
 
-        public DirEntry(ShortformDirectoryEntry entry, Context context)
+        internal Directory CachedDirectory { get; set; }
+
+        private DirEntry(Context context)
         {
-            _entry = entry;
             _context = context;
-            Inode = _context.GetInode(_entry.Inode);
         }
 
+        public DirEntry(IDirectoryEntry entry, Context context):this(context)
+        {
+            _entry = entry;
+            _name = _context.Options.FileNameEncoding.GetString(_entry.Name);
+            Inode = _context.GetInode(_entry.Inode);
+        }
         public Inode Inode { get; private set; }
 
         public override bool IsDirectory
@@ -51,7 +58,7 @@ namespace DiscUtils.Xfs
             get { return Inode.FileType == UnixFileType.Link; }
         }
 
-        public override string FileName { get { return _entry.Name; } }
+        public override string FileName { get { return _name; } }
 
         public override bool HasVfsTimeInfo
         {

--- a/src/Xfs/DirEntry.cs
+++ b/src/Xfs/DirEntry.cs
@@ -29,54 +29,63 @@ namespace DiscUtils.Xfs
 
     internal class DirEntry : VfsDirEntry
     {
+        private readonly ShortformDirectoryEntry _entry;
+        private readonly Context _context;
+
+        public DirEntry(ShortformDirectoryEntry entry, Context context)
+        {
+            _entry = entry;
+            _context = context;
+            Inode = _context.GetInode(_entry.Inode);
+        }
+
+        public Inode Inode { get; private set; }
+
         public override bool IsDirectory
         {
-            get { throw new NotImplementedException(); }
+            get { return Inode.FileType == UnixFileType.Directory; }
         }
 
         public override bool IsSymlink
         {
-            get { throw new NotImplementedException(); }
+            get { return Inode.FileType == UnixFileType.Link; }
         }
 
-        public override string FileName
-        {
-            get { throw new NotImplementedException(); }
-        }
+        public override string FileName { get { return _entry.Name; } }
 
         public override bool HasVfsTimeInfo
         {
-            get { throw new NotImplementedException(); }
+            get { return true; }
         }
 
         public override DateTime LastAccessTimeUtc
         {
-            get { throw new NotImplementedException(); }
+            get { return Inode.AccessTime; }
         }
 
         public override DateTime LastWriteTimeUtc
         {
-            get { throw new NotImplementedException(); }
+            get { return Inode.ModificationTime; }
         }
 
         public override DateTime CreationTimeUtc
         {
-            get { throw new NotImplementedException(); }
+            get { return Inode.CreationTime; }
         }
 
         public override bool HasVfsFileAttributes
         {
-            get { throw new NotImplementedException(); }
+            get { return true; }
         }
 
         public override FileAttributes FileAttributes
         {
-            get { throw new NotImplementedException(); }
+            get { return Utilities.FileAttributesFromUnixFileType(Inode.FileType); ; }
         }
 
         public override long UniqueCacheId
         {
-            get { throw new NotImplementedException(); }
+            get { return ((long)Inode.AllocationGroup) << 32 | Inode.RelativeInodeNumber; }
         }
     }
 }

--- a/src/Xfs/DirEntry.cs
+++ b/src/Xfs/DirEntry.cs
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.IO;
+    using DiscUtils.Vfs;
+
+    internal class DirEntry : VfsDirEntry
+    {
+        public override bool IsDirectory
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override bool IsSymlink
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override string FileName
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override bool HasVfsTimeInfo
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override DateTime LastAccessTimeUtc
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override DateTime LastWriteTimeUtc
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override DateTime CreationTimeUtc
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override bool HasVfsFileAttributes
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override FileAttributes FileAttributes
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override long UniqueCacheId
+        {
+            get { throw new NotImplementedException(); }
+        }
+    }
+}

--- a/src/Xfs/Directory.cs
+++ b/src/Xfs/Directory.cs
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.Collections.Generic;
+    using DiscUtils.Vfs;
+
+    internal class Directory : File, IVfsDirectory<DirEntry, File>
+    {
+        public ICollection<DirEntry> AllEntries
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public DirEntry Self
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public DirEntry GetEntryByName(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public DirEntry CreateNewFile(string name)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xfs/Extent.cs
+++ b/src/Xfs/Extent.cs
@@ -59,5 +59,33 @@ namespace DiscUtils.Xfs
         {
             throw new NotImplementedException();
         }
+
+        public long GetOffset(Context context)
+        {
+            return GetOffset(context, StartBlock);
+        }
+
+        public static long GetOffset(Context context, ulong block)
+        {
+            var daddr = (long)((block >> context.SuperBlock.AgBlocksLog2) * context.SuperBlock.AgBlocks + (block & (1u << context.SuperBlock.AgBlocksLog2) - 1u)) << (context.SuperBlock.BlocksizeLog2 - 9);
+            return daddr * 512;
+        }
+
+        public byte[] GetData(Context context)
+        {
+            return GetData(context, context.SuperBlock.Blocksize*BlockCount);
+        }
+
+        public byte[] GetData(Context context, uint count)
+        {
+            context.RawStream.Position = GetOffset(context);
+            return Utilities.ReadFully(context.RawStream, (int) count);
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"[{StartOffset},{StartBlock},{BlockCount},{Flag}]";
+        }
     }
 }

--- a/src/Xfs/ExtentFlag.cs
+++ b/src/Xfs/ExtentFlag.cs
@@ -22,40 +22,10 @@
 
 namespace DiscUtils.Xfs
 {
-    using System;
-
-    internal abstract class BtreeHeader : IByteArraySerializable
+    internal enum ExtentFlag : byte
     {
-        public uint Magic { get; private set; }
-
-        public ushort Level { get; private set; }
-
-        public ushort NumberOfRecords { get; private set; }
-
-        public int LeftSibling { get; private set; }
-
-        public int RightSibling { get; private set; }
-
-        public virtual int Size
-        {
-            get { return 16; }
-        }
-
-        public virtual int ReadFrom(byte[] buffer, int offset)
-        {
-            Magic = Utilities.ToUInt32BigEndian(buffer, offset);
-            Level = Utilities.ToUInt16BigEndian(buffer, offset + 0x4);
-            NumberOfRecords = Utilities.ToUInt16BigEndian(buffer, offset + 0x6);
-            LeftSibling = Utilities.ToInt32BigEndian(buffer, offset + 0x8);
-            RightSibling = Utilities.ToInt32BigEndian(buffer, offset + 0xC);
-            return 16;
-        }
-
-        public virtual void WriteTo(byte[] buffer, int offset)
-        {
-            throw new NotImplementedException();
-        }
-
-        public abstract void LoadBtree(AllocationGroup ag);
+        Normal,
+        Unwritten,
+        Invalid
     }
 }

--- a/src/Xfs/ExtentStream.cs
+++ b/src/Xfs/ExtentStream.cs
@@ -20,44 +20,28 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+
 namespace DiscUtils.Xfs
 {
     using System;
-    using System.IO;
+    using System.Collections.Generic;
 
-    internal class Extent : IByteArraySerializable
+    internal class ExtentStream : BuiltStream
     {
-        /// <summary>
-        /// Number of Blocks
-        /// </summary>
-        public uint BlockCount { get; private set; }
-
-        public ulong StartBlock { get; private set; }
-
-        public ulong StartOffset { get; private set; }
-
-        public ExtentFlag Flag { get; private set; }
-
-        public int Size
+        /// <inheritdoc />
+        public ExtentStream(long length, List<BuilderExtent> extents) 
+            : base(length, extents)
         {
-            get { return 16; }
         }
 
-        public int ReadFrom(byte[] buffer, int offset)
+        /// <inheritdoc />
+        public override int Read(byte[] buffer, int offset, int count)
         {
-            ulong lower = Utilities.ToUInt64BigEndian(buffer, offset + 0x8);
-            ulong middle = Utilities.ToUInt64BigEndian(buffer, offset + 0x6);
-            ulong upper = Utilities.ToUInt64BigEndian(buffer, offset + 0);
-            BlockCount = (uint)(lower & 0x001FFFFF);
-            StartBlock = (middle >> 5) & 0x000FFFFFFFFFFFFF;
-            StartOffset = (upper >> 9) & 0x003FFFFFFFFFFFFF;
-            Flag = (ExtentFlag) ((buffer[offset + 0x0] >> 6) & 0x3);
-            return Size;
-        }
-
-        public void WriteTo(byte[] buffer, int offset)
-        {
-            throw new NotImplementedException();
+            if (Position + count > Length)
+            {
+                count = (int) (Length - Position);
+            }
+            return base.Read(buffer, offset, count);
         }
     }
 }

--- a/src/Xfs/File.cs
+++ b/src/Xfs/File.cs
@@ -29,82 +29,55 @@ namespace DiscUtils.Xfs
 
     internal class File : IVfsFile
     {
-        private Context _context;
-        private uint _inodeNum;
-        private Inode _inode;
+        protected readonly Context Context;
+        protected readonly Inode Inode;
+        private IBuffer _content;
 
-        public File(Context context, uint inodeNum, Inode inode)
+        public File(Context context, Inode inode)
         {
-            _context = context;
-            _inodeNum = inodeNum;
-            _inode = inode;
+            Context = context;
+            Inode = inode;
         }
 
         public DateTime LastAccessTimeUtc
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
-
-            set
-            {
-                throw new NotImplementedException();
-            }
+            get { return Inode.AccessTime; }
+            set { throw new NotImplementedException(); }
         }
 
         public DateTime LastWriteTimeUtc
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
-
-            set
-            {
-                throw new NotImplementedException();
-            }
+            get { return Inode.ModificationTime; }
+            set { throw new NotImplementedException(); }
         }
 
         public DateTime CreationTimeUtc
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
-
-            set
-            {
-                throw new NotImplementedException();
-            }
+            get { return Inode.CreationTime; }
+            set { throw new NotImplementedException(); }
         }
 
         public FileAttributes FileAttributes
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
-
-            set
-            {
-                throw new NotImplementedException();
-            }
+            get { return Utilities.FileAttributesFromUnixFileType(Inode.FileType); }
+            set { throw new NotImplementedException(); }
         }
 
         public long FileLength
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
+            get { return (long) Inode.Length; }
         }
 
         public IBuffer FileContent
         {
             get
             {
-                throw new NotImplementedException();
+                if (_content == null)
+                {
+                    _content = Inode.GetContentBuffer(Context);
+                }
+
+                return _content;
             }
         }
         

--- a/src/Xfs/File.cs
+++ b/src/Xfs/File.cs
@@ -29,6 +29,16 @@ namespace DiscUtils.Xfs
 
     internal class File : IVfsFile
     {
+        private Context _context;
+        private uint _inodeNum;
+        private Inode _inode;
+
+        public File(Context context, uint inodeNum, Inode inode)
+        {
+            _context = context;
+            _inodeNum = inodeNum;
+            _inode = inode;
+        }
 
         public DateTime LastAccessTimeUtc
         {

--- a/src/Xfs/File.cs
+++ b/src/Xfs/File.cs
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.IO;
+    using DiscUtils.Vfs;
+
+    internal class File : IVfsFile
+    {
+
+        public DateTime LastAccessTimeUtc
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public DateTime LastWriteTimeUtc
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public DateTime CreationTimeUtc
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public FileAttributes FileAttributes
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public long FileLength
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public IBuffer FileContent
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+        
+    }
+}

--- a/src/Xfs/FileSystemFactory.cs
+++ b/src/Xfs/FileSystemFactory.cs
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System.IO;
+    using DiscUtils.Vfs;
+
+    [VfsFileSystemFactory]
+    internal class FileSystemFactory : VfsFileSystemFactory
+    {
+        public override DiscUtils.FileSystemInfo[] Detect(Stream stream, VolumeInfo volume)
+        {
+            if (XfsFileSystem.Detect(stream))
+            {
+                return new DiscUtils.FileSystemInfo[] { new VfsFileSystemInfo("xfs", "Linux xfs family filesystem", Open) };
+            }
+
+            return new DiscUtils.FileSystemInfo[0];
+        }
+
+        private DiscFileSystem Open(Stream stream, VolumeInfo volumeInfo, FileSystemParameters parameters)
+        {
+            return new XfsFileSystem(stream, parameters);
+        }
+    }
+}

--- a/src/Xfs/IDirectoryEntry.cs
+++ b/src/Xfs/IDirectoryEntry.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) 2016, Bianco Veigel
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -23,33 +23,11 @@
 namespace DiscUtils.Xfs
 {
     using System;
-    using System.Text;
-
-    /// <summary>
-    /// XFS file system options.
-    /// </summary>
-    public sealed class XfsFileSystemOptions : DiscFileSystemOptions
+    
+    internal interface IDirectoryEntry
     {
-        internal XfsFileSystemOptions()
-        {
-            FileNameEncoding = Encoding.UTF8;
-        }
+        byte[] Name { get; }
 
-        internal XfsFileSystemOptions(FileSystemParameters parameters)
-        {
-            if (parameters != null && parameters.FileNameEncoding != null)
-            {
-                FileNameEncoding = parameters.FileNameEncoding;
-            }
-            else
-            {
-                FileNameEncoding = Encoding.UTF8;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the character encoding used for file names.
-        /// </summary>
-        public Encoding FileNameEncoding { get; set; }
+        ulong Inode { get; }
     }
 }

--- a/src/Xfs/Inode.cs
+++ b/src/Xfs/Inode.cs
@@ -1,5 +1,4 @@
 //
-// Copyright (c) 2008-2011, Kenneth Bell
 // Copyright (c) 2016, Bianco Veigel
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -24,32 +23,21 @@
 namespace DiscUtils.Xfs
 {
     using System;
-    using System.Collections.Generic;
-    using DiscUtils.Vfs;
+    using System.IO;
 
-    internal class Directory : File, IVfsDirectory<DirEntry, File>
+    internal class Inode : IByteArraySerializable
     {
-        public Directory(Context context, uint inodeNum, Inode inode)
-            : base(context, inodeNum, inode)
-        {
-        }
-
-        public ICollection<DirEntry> AllEntries
+        public int Size
         {
             get { throw new NotImplementedException(); }
         }
 
-        public DirEntry Self
-        {
-            get { throw new NotImplementedException(); }
-        }
-
-        public DirEntry GetEntryByName(string name)
+        public int ReadFrom(byte[] buffer, int offset)
         {
             throw new NotImplementedException();
         }
 
-        public DirEntry CreateNewFile(string name)
+        public void WriteTo(byte[] buffer, int offset)
         {
             throw new NotImplementedException();
         }

--- a/src/Xfs/Inode.cs
+++ b/src/Xfs/Inode.cs
@@ -20,6 +20,9 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using DiscUtils.Udf;
+using DiscUtils.Vhd;
+
 namespace DiscUtils.Xfs
 {
     using System;
@@ -27,18 +30,251 @@ namespace DiscUtils.Xfs
 
     internal class Inode : IByteArraySerializable
     {
+        public Inode(ulong number, Context context)
+        {
+            var sb = context.SuperBlock;
+            RelativeInodeNumber = (uint) (number & sb.RelativeInodeMask);
+            AllocationGroup = (uint) ((number & sb.AgInodeMask) >> (sb.AgBlocksLog2 + sb.InodesPerBlockLog2));
+            AgBlock = (uint) ((number >> context.SuperBlock.InodesPerBlockLog2) & XFS_INO_MASK(context.SuperBlock.AgBlocksLog2));
+            BlockOffset = (uint) (number & XFS_INO_MASK(sb.InodesPerBlockLog2));
+        }
+
+        private static uint XFS_INO_MASK(int k)
+        {
+            return (1u << k) - 1;
+        }
+
+        public Inode(uint allocationGroup, uint relInode)
+        {
+            AllocationGroup = allocationGroup;
+            RelativeInodeNumber = relInode;
+        }
+
+        public uint AllocationGroup { get; private set; }
+
+        public uint RelativeInodeNumber { get; private set; }
+
+        public uint AgBlock { get; private set; }
+
+        public uint BlockOffset { get; private set; }
+
+        public const ushort InodeMagic = 0x494e;
+        /// <summary>
+        /// The inode signature where these two bytes are 0x494e, or "IN" in ASCII.
+        /// </summary>
+        public ushort Magic { get; private set; }
+
+        /// <summary>
+        /// Specifies the mode access bits and type of file using the standard S_Ixxx values defined in stat.h.
+        /// </summary>
+        public ushort Mode { get; private set; }
+
+        /// <summary>
+        /// Specifies the inode version which currently can only be 1 or 2. The inode version specifies the
+        /// usage of the di_onlink, di_nlink and di_projid values in the inode core.Initially, inodes
+        /// are created as v1 but can be converted on the fly to v2 when required.
+        /// </summary>
+        public byte Version { get; private set; }
+
+        /// <summary>
+        /// Specifies the format of the data fork in conjunction with the di_mode type. This can be one of
+        /// several values. For directories and links, it can be "local" where all metadata associated with the
+        /// file is within the inode, "extents" where the inode contains an array of extents to other filesystem
+        /// blocks which contain the associated metadata or data or "btree" where the inode contains a
+        /// B+tree root node which points to filesystem blocks containing the metadata or data. Migration
+        /// between the formats depends on the amount of metadata associated with the inode. "dev" is
+        /// used for character and block devices while "uuid" is currently not used.
+        /// </summary>
+        public InodeFormat Format { get; private set; }
+
+        /// <summary>
+        /// In v1 inodes, this specifies the number of links to the inode from directories. When the number
+        /// exceeds 65535, the inode is converted to v2 and the link count is stored in di_nlink.
+        /// </summary>
+        public ushort Onlink { get; private set; }
+
+        /// <summary>
+        /// Specifies the owner's UID of the inode.
+        /// </summary>
+        public uint UserId { get; private set; }
+
+        /// <summary>
+        /// Specifies the owner's GID of the inode.
+        /// </summary>
+        public uint GroupId { get; private set; }
+
+        /// <summary>
+        /// Specifies the number of links to the inode from directories. This is maintained for both inode
+        /// versions for current versions of XFS.Old versions of XFS did not support v2 inodes, and
+        /// therefore this value was never updated and was classed as reserved space (part of <see cref="Padding"/>).
+        /// </summary>
+        public uint Nlink { get; private set; }
+
+        /// <summary>
+        /// Specifies the owner's project ID in v2 inodes. An inode is converted to v2 if the project ID is set.
+        /// This value must be zero for v1 inodes.
+        /// </summary>
+        public ushort ProjectId { get; private set; }
+
+        /// <summary>
+        /// Reserved, must be zero.
+        /// </summary>
+        public byte[] Padding { get; private set; }
+
+        /// <summary>
+        /// Incremented on flush.
+        /// </summary>
+        public ushort FlushIterator { get; private set; }
+
+        /// <summary>
+        /// Specifies the last access time of the files using UNIX time conventions the following structure.
+        /// This value maybe undefined if the filesystem is mounted with the "noatime" option.
+        /// </summary>
+        public DateTime AccessTime { get; private set; }
+
+        /// <summary>
+        /// Specifies the last time the file was modified.
+        /// </summary>
+        public DateTime ModificationTime { get; private set; }
+
+        /// <summary>
+        /// Specifies when the inode's status was last changed.
+        /// </summary>
+        public DateTime CreationTime { get; private set; }
+
+        /// <summary>
+        /// Specifies the EOF of the inode in bytes. This can be larger or smaller than the extent space
+        /// (therefore actual disk space) used for the inode.For regular files, this is the filesize in bytes,
+        /// directories, the space taken by directory entries and for links, the length of the symlink.
+        /// </summary>
+        public ulong Length { get; private set; }
+
+        /// <summary>
+        /// Specifies the number of filesystem blocks used to store the inode's data including relevant
+        /// metadata like B+trees.This does not include blocks used for extended attributes.
+        /// </summary>
+        public ulong BlockCount { get; private set; }
+
+        /// <summary>
+        /// Specifies the extent size for filesystems with real-time devices and an extent size hint for
+        /// standard filesystems. For normal filesystems, and with directories, the
+        /// XFS_DIFLAG_EXTSZINHERIT flag must be set in di_flags if this field is used.Inodes
+        /// created in these directories will inherit the di_extsize value and have
+        /// XFS_DIFLAG_EXTSIZE set in their di_flags. When a file is written to beyond allocated
+        /// space, XFS will attempt to allocate additional disk space based on this value.
+        /// </summary>
+        public uint ExtentSize { get; private set; }
+
+        /// <summary>
+        /// Specifies the number of data extents associated with this inode.
+        /// </summary>
+        public uint Extents { get; private set; }
+
+        /// <summary>
+        /// Specifies the number of extended attribute extents associated with this inode.
+        /// </summary>
+        public ushort AttributeExtents { get; private set; }
+
+        /// <summary>
+        /// Specifies the offset into the inode's literal area where the extended attribute fork starts. This is
+        /// an 8-bit value that is multiplied by 8 to determine the actual offset in bytes(ie.attribute data is
+        /// 64-bit aligned). This also limits the maximum size of the inode to 2048 bytes.This value is
+        /// initially zero until an extended attribute is created.When in attribute is added, the nature of
+        /// di_forkoff depends on the XFS_SB_VERSION2_ATTR2BIT flag in the superblock.
+        /// </summary>
+        public byte Forkoff { get; private set; }
+
+        /// <summary>
+        /// Specifies the format of the attribute fork. This uses the same values as di_format, but
+        /// restricted to "local", "extents" and "btree" formats for extended attribute data.
+        /// </summary>
+        public sbyte AttributeFormat { get; private set; }
+
+        /// <summary>
+        /// DMAPI event mask.
+        /// </summary>
+        public uint DmApiEventMask { get; private set; }
+
+        /// <summary>
+        /// DMAPI state.
+        /// </summary>
+        public ushort DmState { get; private set; }
+
+        /// <summary>
+        /// Specifies flags associated with the inode.
+        /// </summary>
+        public InodeFlags Flags { get; private set; }
+
+        /// <summary>
+        /// A generation number used for inode identification. This is used by tools that do inode scanning
+        /// such as backup tools and xfsdump. An inode's generation number can change by unlinking and
+        /// creating a new file that reuses the inode.
+        /// </summary>
+        public uint Generation { get; private set; }
+        
+        public UnixFileType FileType { get { return (UnixFileType) ((Mode >> 12) & 0xF); } }
+
+        public byte[] DataFork { get; private set; }
+
         public int Size
         {
-            get { throw new NotImplementedException(); }
+            get { return 96; }
         }
 
         public int ReadFrom(byte[] buffer, int offset)
         {
-            throw new NotImplementedException();
+            Magic = Utilities.ToUInt16BigEndian(buffer, offset);
+            Mode = Utilities.ToUInt16BigEndian(buffer, offset + 0x2);
+            Version = buffer[offset + 0x4];
+            Format = (InodeFormat)buffer[offset + 0x5];
+            Onlink = Utilities.ToUInt16BigEndian(buffer, offset + 0x6);
+            UserId = Utilities.ToUInt32BigEndian(buffer, offset + 0x8);
+            GroupId = Utilities.ToUInt32BigEndian(buffer, offset + 0xC);
+            Nlink = Utilities.ToUInt32BigEndian(buffer, offset + 0x10);
+            ProjectId = Utilities.ToUInt16BigEndian(buffer, offset + 0x14);
+            Padding = Utilities.ToByteArray(buffer, offset + 0x16, 8);
+            FlushIterator = Utilities.ToUInt16BigEndian(buffer, 0x1E);
+            AccessTime = ReadTimestamp(buffer, offset + 0x20);
+            ModificationTime = ReadTimestamp(buffer, offset + 0x28);
+            CreationTime = ReadTimestamp(buffer, offset + 0x30);
+            Length = Utilities.ToUInt64BigEndian(buffer, offset + 0x38);
+            BlockCount = Utilities.ToUInt64BigEndian(buffer, offset + 0x40);
+            ExtentSize = Utilities.ToUInt32BigEndian(buffer, offset + 0x48);
+            Extents = Utilities.ToUInt32BigEndian(buffer, offset + 0x4C);
+            AttributeExtents = Utilities.ToUInt16BigEndian(buffer, offset + 0x50);
+            Forkoff = buffer[offset + 0x52];
+            AttributeFormat = (sbyte) buffer[offset + 0x53];
+            DmApiEventMask = Utilities.ToUInt32BigEndian(buffer, offset + 0x54);
+            DmState = Utilities.ToUInt16BigEndian(buffer, offset + 0x58);
+            Flags = (InodeFlags) Utilities.ToUInt16BigEndian(buffer, offset + 0x5A);
+            Generation = Utilities.ToUInt32BigEndian(buffer, offset + 0x5C);
+            var dfLength = (Forkoff*8) - 0x64;
+            if (dfLength < 0)
+            {
+                dfLength = buffer.Length - offset - 0x64;
+            }
+            DataFork = Utilities.ToByteArray(buffer, offset + 0x64, dfLength);
+            return Size;
+        }
+
+        private DateTime ReadTimestamp(byte[] buffer, int offset)
+        {
+            var seconds = Utilities.ToUInt32BigEndian(buffer, offset);
+            var nanoSeconds = Utilities.ToUInt32BigEndian(buffer, offset + 0x4);
+            return Utilities.DateTimeFromUnix(seconds).AddTicks(nanoSeconds/100);
         }
 
         public void WriteTo(byte[] buffer, int offset)
         {
+            throw new NotImplementedException();
+        }
+
+        public IBuffer GetContentBuffer(Context context)
+        {
+            if (Format == InodeFormat.Extents)
+            {
+                throw new NotImplementedException();
+            }
             throw new NotImplementedException();
         }
     }

--- a/src/Xfs/InodeFlags.cs
+++ b/src/Xfs/InodeFlags.cs
@@ -1,0 +1,107 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    
+    [Flags]
+    internal enum InodeFlags : ushort
+    {
+        None = 0,
+
+        /// <summary>
+        /// The inode's data is located on the real-time device.
+        /// </summary>
+        Realtime = (1 << 0),
+
+        /// <summary>
+        /// The inode's extents have been preallocated.
+        /// </summary>
+        Prealloc = (1 << 1),
+
+        /// <summary>
+        /// Specifies the sb_rbmino uses the new real-time bitmap format
+        /// </summary>
+        NewRtBitmap = (1 << 2),
+
+        /// <summary>
+        /// Specifies the inode cannot be modified.
+        /// </summary>
+        Immutable = (1 << 3),
+
+        /// <summary>
+        /// The inode is in append only mode.
+        /// </summary>
+        Append = (1 << 4),
+
+        /// <summary>
+        /// The inode is written synchronously.
+        /// </summary>
+        Sync = (1 << 5),
+
+        /// <summary>
+        /// The inode's di_atime is not updated.
+        /// </summary>
+        NoAtime = (1 << 6),
+
+        /// <summary>
+        /// Specifies the inode is to be ignored by xfsdump.
+        /// </summary>
+        NoDump = (1 << 7),
+
+        /// <summary>
+        /// For directory inodes, new inodes inherit the XFS_DIFLAG_REALTIME bit.
+        ///  </summary>
+        RtInherit = (1 << 8),
+
+        /// <summary>
+        /// For directory inodes, new inodes inherit the <see cref="Inode.ProjectId"/> value.
+        /// </summary>
+        ProjInherit = (1 << 9),
+
+        /// <summary>
+        /// For directory inodes, symlinks cannot be created.
+        /// </summary>
+        NoSymlinks = (1 << 10),
+
+        /// <summary>
+        /// Specifies the extent size for real-time files or a and extent size hint for regular files.
+        /// </summary>
+        ExtentSize = (1 << 11),
+
+        /// <summary>
+        /// For directory inodes, new inodes inherit the <see cref="Inode.ExtentSize"/> value.
+        /// </summary>
+        ExtentSizeInherit = (1 << 12),
+
+        /// <summary>
+        /// Specifies the inode is to be ignored when defragmenting the filesystem.
+        /// </summary>
+        NoDefrag = (1 << 13),
+
+        /// <summary>
+        /// use filestream allocator
+        /// </summary>
+        Filestream = (1 << 14)
+    }
+}

--- a/src/Xfs/InodeFormat.cs
+++ b/src/Xfs/InodeFormat.cs
@@ -22,40 +22,31 @@
 
 namespace DiscUtils.Xfs
 {
-    using System;
-
-    internal abstract class BtreeHeader : IByteArraySerializable
+    internal enum InodeFormat : byte
     {
-        public uint Magic { get; private set; }
+        /// <summary>
+        /// character and block devices
+        /// </summary>
+        Dev,
 
-        public ushort Level { get; private set; }
+        /// <summary>
+        /// all metadata associated with the file is within the inode
+        /// </summary>
+        Local,
 
-        public ushort NumberOfRecords { get; private set; }
+        /// <summary>
+        /// the inode contains an array of extents to other filesystem blocks which contain the associated metadata or data
+        /// </summary>
+        Extents,
 
-        public int LeftSibling { get; private set; }
+        /// <summary>
+        /// the inode contains a B+tree root node which points to filesystem blocks containing the metadata or data 
+        /// </summary>
+        Btree,
 
-        public int RightSibling { get; private set; }
-
-        public virtual int Size
-        {
-            get { return 16; }
-        }
-
-        public virtual int ReadFrom(byte[] buffer, int offset)
-        {
-            Magic = Utilities.ToUInt32BigEndian(buffer, offset);
-            Level = Utilities.ToUInt16BigEndian(buffer, offset + 0x4);
-            NumberOfRecords = Utilities.ToUInt16BigEndian(buffer, offset + 0x6);
-            LeftSibling = Utilities.ToInt32BigEndian(buffer, offset + 0x8);
-            RightSibling = Utilities.ToInt32BigEndian(buffer, offset + 0xC);
-            return 16;
-        }
-
-        public virtual void WriteTo(byte[] buffer, int offset)
-        {
-            throw new NotImplementedException();
-        }
-
-        public abstract void LoadBtree(AllocationGroup ag);
+        /// <summary>
+        /// currently not used
+        /// </summary>
+        Uuid
     }
 }

--- a/src/Xfs/LeafDirectory.cs
+++ b/src/Xfs/LeafDirectory.cs
@@ -23,19 +23,16 @@
 namespace DiscUtils.Xfs
 {
     using System;
-    using System.IO;
     using System.Collections.Generic;
 
-    internal class BlockDirectory : IByteArraySerializable
+    internal class LeafDirectory : IByteArraySerializable
     {
-        public const uint HeaderMagic = 0x58443242;
+        public const uint HeaderMagic = 0x58443244;
+
+        public const ulong LeafOffset = (1* (1UL << (32 + 3)));
 
         public uint Magic { get; private set; }
-
-        public uint LeafCount { get; private set; }
-
-        public uint LeafStale { get; private set; }
-
+        
         public BlockDirectoryDataFree[] BestFree { get; private set; }
 
         public BlockDirectoryData[] Entries { get; private set; }
@@ -56,11 +53,9 @@ namespace DiscUtils.Xfs
                 offset += free.ReadFrom(buffer, offset);
                 BestFree[i] = free;
             }
-
-            LeafStale = Utilities.ToUInt32BigEndian(buffer, buffer.Length - 0x4);
-            LeafCount = Utilities.ToUInt32BigEndian(buffer, buffer.Length - 0x8);
+            
             var entries = new List<BlockDirectoryData>();
-            var eof = buffer.Length - 0x8 - LeafCount*0x8;
+            var eof = buffer.Length;
             while (offset < eof)
             {
                 BlockDirectoryData entry;

--- a/src/Xfs/ReadOnlyCompatibleFeatures.cs
+++ b/src/Xfs/ReadOnlyCompatibleFeatures.cs
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>
+    /// Feature flags for features backwards compatible with read-only mounting.
+    /// </summary>
+    [Flags]
+    internal enum ReadOnlyCompatibleFeatures : uint
+    {
+        /// <summary>
+        /// free inode btree
+        /// </summary>
+        FINOBT = (1 << 0),
+
+        /// <summary>
+        /// reverse map btree
+        /// </summary>
+        RMAPBT = (1 << 1),
+
+        /// <summary>
+        /// reflinked files
+        /// </summary>
+        REFLINK = (1 << 2),
+
+        ALL = FINOBT | RMAPBT | REFLINK,
+    }
+}

--- a/src/Xfs/ShortformDirectory.cs
+++ b/src/Xfs/ShortformDirectory.cs
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.IO;
+
+    internal class ShortformDirectory : IByteArraySerializable
+    {
+        private bool _useShortInode;
+
+        public byte Count4Bytes { get; private set; }
+
+        public byte Count8Bytes { get; private set; }
+
+        public ulong Parent { get; set; }
+
+        public ShortformDirectoryEntry[] Entries { get; private set; }
+
+        public int Size
+        {
+            get
+            {
+                var result = 0x6;
+                foreach (var entry in Entries)
+                {
+                    result += entry.Size;
+                }
+                return result;
+            }
+        }
+
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Count4Bytes = buffer[offset];
+            Count8Bytes = buffer[offset+0x1];
+            byte count;
+            _useShortInode = false;
+            Parent = Utilities.ToUInt32BigEndian(buffer, offset + 0x2);
+            offset = offset + 0x6;
+            if (Count4Bytes != 0)
+            {
+                _useShortInode = true;
+                count = Count4Bytes;
+            }
+            else if (Count8Bytes != 0)
+            {
+                count = Count8Bytes;
+            }
+            else
+            {
+                throw new IOException("Empty directory inode - undefined");
+            }
+            Entries = new ShortformDirectoryEntry[count];
+            for (int i = 0; i < count; i++)
+            {
+                var entry = new ShortformDirectoryEntry(_useShortInode);
+                entry.ReadFrom(buffer, offset);
+                offset += entry.Size;
+                Entries[i] = entry;
+            }
+            return Size;
+        }
+
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Xfs/ShortformDirectory.cs
+++ b/src/Xfs/ShortformDirectory.cs
@@ -69,7 +69,7 @@ namespace DiscUtils.Xfs
             }
             else
             {
-                throw new IOException("Empty directory inode - undefined");
+                count = 0;
             }
             Entries = new ShortformDirectoryEntry[count];
             for (int i = 0; i < count; i++)

--- a/src/Xfs/ShortformDirectoryEntry.cs
+++ b/src/Xfs/ShortformDirectoryEntry.cs
@@ -25,7 +25,7 @@ namespace DiscUtils.Xfs
     using System;
     using System.IO;
 
-    internal class ShortformDirectoryEntry : IByteArraySerializable
+    internal class ShortformDirectoryEntry : IByteArraySerializable, IDirectoryEntry
     {
         private readonly bool _useShortInode;
 
@@ -38,7 +38,7 @@ namespace DiscUtils.Xfs
 
         public ushort Offset { get; private set; }
 
-        public string Name { get; private set; }
+        public byte[] Name { get; private set; }
 
         public ulong Inode { get; private set; }
 
@@ -51,7 +51,7 @@ namespace DiscUtils.Xfs
         {
             NameLength = buffer[offset];
             Offset = Utilities.ToUInt16BigEndian(buffer, offset + 0x1);
-            Name = Utilities.BytesToString(buffer, offset + 0x3, NameLength);
+            Name = Utilities.ToByteArray(buffer, offset + 0x3, NameLength);
             if (_useShortInode)
             {
                 Inode = Utilities.ToUInt32BigEndian(buffer, offset + 0x3 + NameLength);
@@ -66,6 +66,12 @@ namespace DiscUtils.Xfs
         public void WriteTo(byte[] buffer, int offset)
         {
             throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{Inode}: {Utilities.BytesToString(Name, 0, NameLength)}";
         }
     }
 }

--- a/src/Xfs/SuperBlock.cs
+++ b/src/Xfs/SuperBlock.cs
@@ -1,0 +1,408 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+
+    internal class SuperBlock : IByteArraySerializable
+    {
+        public const uint XfsMagic = 0x58465342;
+        /// <summary>
+        /// magic number == XFS_SB_MAGIC
+        /// </summary>
+        public uint Magic;
+        /// <summary>
+        /// logical block size, bytes
+        /// </summary>
+        public uint Blocksize;
+
+        /// <summary>
+        /// number of data blocks
+        /// </summary>
+        public ulong DataBlocks;
+
+        /// <summary>
+        /// number of realtime blocks
+        /// </summary>
+        public ulong RealtimeBlocks;
+
+        /// <summary>
+        /// number of realtime extents
+        /// </summary>
+        public ulong RealtimeExtents;
+
+        /// <summary>
+        /// user-visible file system unique id
+        /// </summary>
+        public Guid UniqueId;
+
+        /// <summary>
+        /// starting block of log if internal
+        /// </summary>
+        public ulong Logstart;
+
+        /// <summary>
+        /// root inode number
+        /// </summary>
+        public ulong RootInode;
+
+        /// <summary>
+        /// bitmap inode for realtime extents
+        /// </summary>
+        public ulong RealtimeBitmapInode;
+
+        /// <summary>
+        /// summary inode for rt bitmap
+        /// </summary>
+        public ulong RealtimeSummaryInode;
+
+        /// <summary>
+        /// realtime extent size, blocks
+        /// </summary>
+        public uint RealtimeExtentSize;
+
+        /// <summary>
+        /// size of an allocation group
+        /// </summary>
+        public uint AgBlocks;
+
+        /// <summary>
+        /// number of allocation groups
+        /// </summary>
+        public uint AgCount;
+
+        /// <summary>
+        /// number of rt bitmap blocks
+        /// </summary>
+        public uint RealtimeBitmapBlocks;
+
+        /// <summary>
+        /// number of log blocks
+        /// </summary>
+        public uint LogBlocks;
+
+        /// <summary>
+        /// header version == XFS_SB_VERSION
+        /// </summary>
+        public ushort Version;
+
+        /// <summary>
+        /// volume sector size, bytes
+        /// </summary>
+        public ushort SectorSize;
+
+        /// <summary>
+        /// inode size, bytes
+        /// </summary>
+        public ushort InodeSize;
+
+        /// <summary>
+        /// inodes per block
+        /// </summary>
+        public ushort InodesPerBlock;
+
+        /// <summary>
+        /// file system name
+        /// </summary>
+        public string FilesystemName;
+
+        /// <summary>
+        /// log2 of <see cref="Blocksize"/>
+        /// </summary>
+        public byte BlocksizeLog2;
+
+        /// <summary>
+        /// log2 of <see cref="SectorSize"/>
+        /// </summary>
+        public byte SectorSizeLog2;
+
+        /// <summary>
+        /// log2 of <see cref="InodeSize"/>
+        /// </summary>
+        public byte InodeSizeLog2;
+
+        /// <summary>
+        /// log2 of <see cref="InodesPerBlock"/>
+        /// </summary>
+        public byte InodesPerBlockLog2;
+
+        /// <summary>
+        /// log2 of <see cref="AgBlocks"/> (rounded up)
+        /// </summary>
+        public byte AgBlocksLog2;
+
+        /// <summary>
+        /// log2 of <see cref="RealtimeExtents"/>
+        /// </summary>
+        public byte RealtimeExtentsLog2;
+
+        /// <summary>
+        /// mkfs is in progress, don't mount
+        /// </summary>
+        public byte InProgress;
+
+        /// <summary>
+        /// max % of fs for inode space
+        /// </summary>
+        public byte InodesMaxPercent;
+
+         /*
+         * These fields must remain contiguous.  If you really
+         * want to change their layout, make sure you fix the
+         * code in xfs_trans_apply_sb_deltas().
+         */                           
+        #region statistics
+        
+        /// <summary>
+        /// allocated inodes
+        /// </summary>
+        public ulong AllocatedInodes;
+
+        /// <summary>
+        /// free inodes
+        /// </summary>
+        public ulong FreeInodes;
+
+        /// <summary>
+        /// free data blocks
+        /// </summary>
+        public ulong FreeDataBlocks;
+
+        /// <summary>
+        /// free realtime extents
+        /// </summary>
+        public ulong FreeRealtimeExtents;
+        
+        #endregion
+
+        /// <summary>
+        /// user quota inode
+        /// </summary>
+        public ulong UserQuotaInode;
+        
+        /// <summary>
+        /// group quota inode
+        /// </summary>
+        public ulong GroupQuotaInode;
+        
+        /// <summary>
+        /// quota flags
+        /// </summary>
+        public ushort QuotaFlags;
+
+        /// <summary>
+        /// misc. flags
+        /// </summary>
+        public byte Flags;
+        
+        /// <summary>
+        /// shared version number
+        /// </summary>
+        public byte SharedVersionNumber;
+        
+        /// <summary>
+        /// inode chunk alignment, fsblocks
+        /// </summary>
+        public uint InodeChunkAlignment;
+        
+        /// <summary>
+        /// stripe or raid unit
+        /// </summary>
+        public uint Unit;
+        
+        /// <summary>
+        /// stripe or raid width
+        /// </summary>
+        public uint Width;
+
+        /// <summary>
+        /// log2 of dir block size (fsbs)
+        /// </summary>
+        public byte DirBlockLog2;
+        
+        /// <summary>
+        /// log2 of the log sector size
+        /// </summary>
+        public byte LogSectorSizeLog2;
+        
+        /// <summary>
+        /// sector size for the log, bytes
+        /// </summary>
+        public ushort LogSectorSize;
+        
+        /// <summary>
+        /// stripe unit size for the log
+        /// </summary>
+        public uint LogUnitSize;
+        
+        /// <summary>
+        /// additional feature bits
+        /// </summary>
+        public uint Features2;
+
+        /*
+        * bad features2 field as a result of failing to pad the sb structure to
+        * 64 bits. Some machines will be using this field for features2 bits.
+        * Easiest just to mark it bad and not use it for anything else.
+        *
+        * This is not kept up to date in memory; it is always overwritten by
+        * the value in sb_features2 when formatting the incore superblock to
+        * the disk buffer.
+        */
+        /// <summary>
+        /// bad features2 field as a result of failing to pad the sb structure to
+        /// 64 bits. Some machines will be using this field for features2 bits.
+        /// Easiest just to mark it bad and not use it for anything else.
+        /// 
+        /// This is not kept up to date in memory; it is always overwritten by
+        /// the value in sb_features2 when formatting the incore superblock to
+        /// the disk buffer.
+        /// </summary>
+        public uint BadFeatures2;
+
+        /* version 5 superblock fields start here */
+
+        /* feature masks */
+        public uint CompatibleFeatures;
+        public ReadOnlyCompatibleFeatures ReadOnlyCompatibleFeatures;
+        public uint IncompatibleFeatures;
+        public uint LogIncompatibleFeatures;
+
+        /// <summary>
+        /// superblock crc
+        /// </summary>
+        public uint Crc;
+
+        /// <summary>
+        /// sparse inode chunk alignment
+        /// </summary>
+        public uint SparseInodeAlignment;
+
+        /// <summary>
+        /// project quota inode
+        /// </summary>
+        public ulong ProjectQuotaInode;
+
+        /// <summary>
+        /// last write sequence
+        /// </summary>
+        public long Lsn;
+
+        /// <summary>
+        /// metadata file system unique id
+        /// </summary>
+        public Guid MetaUuid;
+
+        /* must be padded to 64 bit alignment */
+
+        public int Size
+        {
+            get { return 264; }
+        }
+
+        public int ReadFrom(byte[] buffer, int offset)
+        {
+            Magic = Utilities.ToUInt32BigEndian(buffer, offset);
+            Blocksize = Utilities.ToUInt32BigEndian(buffer, offset + 0x4);
+            DataBlocks = Utilities.ToUInt64BigEndian(buffer, offset + 0x8);
+            RealtimeBlocks = Utilities.ToUInt64BigEndian(buffer, offset + 0x10);
+            RealtimeExtents = Utilities.ToUInt64BigEndian(buffer, offset + 0x18);
+            UniqueId = Utilities.ToGuidBigEndian(buffer, offset + 0x20);
+            Logstart = Utilities.ToUInt64BigEndian(buffer, offset + 0x30);
+            RootInode = Utilities.ToUInt64BigEndian(buffer, offset + 0x38);
+            RealtimeBitmapInode = Utilities.ToUInt64BigEndian(buffer, offset + 0x40);
+            RealtimeSummaryInode = Utilities.ToUInt64BigEndian(buffer, offset + 0x48);
+            RealtimeExtentSize = Utilities.ToUInt32BigEndian(buffer, offset + 0x50);
+            AgBlocks = Utilities.ToUInt32BigEndian(buffer, offset + 0x54);
+            AgCount = Utilities.ToUInt32BigEndian(buffer, offset + 0x58);
+            RealtimeBitmapBlocks = Utilities.ToUInt32BigEndian(buffer, offset + 0x5C);
+            LogBlocks = Utilities.ToUInt32BigEndian(buffer, offset + 0x60);
+            Version = Utilities.ToUInt16BigEndian(buffer, offset + 0x64);
+            SectorSize = Utilities.ToUInt16BigEndian(buffer, offset + 0x66);
+            InodeSize = Utilities.ToUInt16BigEndian(buffer, offset + 0x68);
+            InodesPerBlock = Utilities.ToUInt16BigEndian(buffer, offset + 0x6A);
+            FilesystemName = Utilities.BytesToZString(buffer, offset + 0x6C, 12);
+            BlocksizeLog2 = buffer[offset + 0x78];
+            SectorSizeLog2 = buffer[offset + 0x79];
+            InodeSizeLog2 = buffer[offset + 0x7A];
+            InodesPerBlockLog2 = buffer[offset + 0x7B];
+            AgBlocksLog2 = buffer[offset + 0x7C];
+            RealtimeExtentsLog2 = buffer[offset + 0x7D];
+            InProgress = buffer[offset + 0x7E];
+            InodesMaxPercent = buffer[offset + 0x7F];
+            AllocatedInodes = Utilities.ToUInt64BigEndian(buffer, offset + 0x80);
+            FreeInodes = Utilities.ToUInt64BigEndian(buffer, offset + 0x88);
+            FreeDataBlocks = Utilities.ToUInt64BigEndian(buffer, offset + 0x90);
+            FreeRealtimeExtents = Utilities.ToUInt64BigEndian(buffer, offset + 0x98);
+            UserQuotaInode = Utilities.ToUInt64BigEndian(buffer, offset + 0xA0);
+            GroupQuotaInode = Utilities.ToUInt64BigEndian(buffer, offset + 0xA8);
+            QuotaFlags = Utilities.ToUInt16BigEndian(buffer, offset + 0xB0);
+            Flags = buffer[offset + 0xB2];
+            SharedVersionNumber = buffer[offset + 0xB3];
+            InodeChunkAlignment = Utilities.ToUInt32BigEndian(buffer, offset + 0xB4);
+            Unit = Utilities.ToUInt32BigEndian(buffer, offset + 0xB8);
+            Width = Utilities.ToUInt32BigEndian(buffer, offset + 0xBC);
+            DirBlockLog2 = buffer[offset + 0xC0];
+            LogSectorSizeLog2 = buffer[offset + 0xC1];
+            LogSectorSize = Utilities.ToUInt16BigEndian(buffer, offset + 0xC2);
+            LogUnitSize = Utilities.ToUInt32BigEndian(buffer, offset + 0xC4);
+            Features2 = Utilities.ToUInt32BigEndian(buffer, offset + 0xC8);
+            BadFeatures2 = Utilities.ToUInt32BigEndian(buffer, offset + 0xCC);
+            CompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0xD0);
+            ReadOnlyCompatibleFeatures = (ReadOnlyCompatibleFeatures)Utilities.ToUInt32BigEndian(buffer, offset + 0xD4);
+            IncompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0xD8);
+            LogIncompatibleFeatures = Utilities.ToUInt32BigEndian(buffer, offset + 0xDC);
+            Crc = Utilities.ToUInt32BigEndian(buffer, offset + 0xE0);
+            SparseInodeAlignment = Utilities.ToUInt32BigEndian(buffer, offset + 0xE4);
+            ProjectQuotaInode = Utilities.ToUInt64BigEndian(buffer, offset + 0xE8);
+            Lsn = Utilities.ToInt64BigEndian(buffer, offset + 0xF0);
+            MetaUuid = Utilities.ToGuidBigEndian(buffer, offset + 0xF8);
+            return 264;
+        }
+
+        public void WriteTo(byte[] buffer, int offset)
+        {
+            throw new NotImplementedException();
+        }
+
+        public uint xfs_btree_compute_maxlevels()
+        {
+            var len = AgBlocks;
+            uint level;
+            var limits = new uint[] {xfs_rmapbt_maxrecs(false), xfs_rmapbt_maxrecs(true)};
+            ulong maxblocks = (len + limits[0] - 1) / limits[0];
+            for (level = 1; maxblocks > 1; level++)
+                maxblocks = (maxblocks + limits[1] - 1) / limits[1];
+            return level;
+        }
+
+        private uint xfs_rmapbt_maxrecs(bool leaf)
+        {
+            var blocklen = Blocksize - 56;
+            if (leaf)
+                return blocklen/24;
+            return blocklen/(2*20 + 4);
+        }
+    }
+}

--- a/src/Xfs/SuperBlock.cs
+++ b/src/Xfs/SuperBlock.cs
@@ -319,6 +319,10 @@ namespace DiscUtils.Xfs
 
         /* must be padded to 64 bit alignment */
 
+        public uint RelativeInodeMask { get; private set; }
+
+        public uint AgInodeMask { get; private set; }
+
         public int Size
         {
             get { return 264; }
@@ -381,6 +385,11 @@ namespace DiscUtils.Xfs
             ProjectQuotaInode = Utilities.ToUInt64BigEndian(buffer, offset + 0xE8);
             Lsn = Utilities.ToInt64BigEndian(buffer, offset + 0xF0);
             MetaUuid = Utilities.ToGuidBigEndian(buffer, offset + 0xF8);
+
+
+            var agOffset = AgBlocksLog2 + InodesPerBlockLog2;
+            RelativeInodeMask = 0xffffffff >> (32-agOffset);
+            AgInodeMask = ~RelativeInodeMask;
             return 264;
         }
 

--- a/src/Xfs/SuperBlock.cs
+++ b/src/Xfs/SuperBlock.cs
@@ -323,6 +323,8 @@ namespace DiscUtils.Xfs
 
         public uint AgInodeMask { get; private set; }
 
+        public uint DirBlockSize { get; private set; }
+
         public int Size
         {
             get { return 264; }
@@ -386,10 +388,11 @@ namespace DiscUtils.Xfs
             Lsn = Utilities.ToInt64BigEndian(buffer, offset + 0xF0);
             MetaUuid = Utilities.ToGuidBigEndian(buffer, offset + 0xF8);
 
-
             var agOffset = AgBlocksLog2 + InodesPerBlockLog2;
             RelativeInodeMask = 0xffffffff >> (32-agOffset);
             AgInodeMask = ~RelativeInodeMask;
+
+            DirBlockSize = Blocksize << DirBlockLog2;
             return 264;
         }
 

--- a/src/Xfs/SuperBlock.cs
+++ b/src/Xfs/SuperBlock.cs
@@ -31,235 +31,235 @@ namespace DiscUtils.Xfs
         /// <summary>
         /// magic number == XFS_SB_MAGIC
         /// </summary>
-        public uint Magic;
+        public uint Magic { get; private set; }
         /// <summary>
         /// logical block size, bytes
         /// </summary>
-        public uint Blocksize;
+        public uint Blocksize { get; private set; }
 
         /// <summary>
         /// number of data blocks
         /// </summary>
-        public ulong DataBlocks;
+        public ulong DataBlocks { get; private set; }
 
         /// <summary>
         /// number of realtime blocks
         /// </summary>
-        public ulong RealtimeBlocks;
+        public ulong RealtimeBlocks { get; private set; }
 
         /// <summary>
         /// number of realtime extents
         /// </summary>
-        public ulong RealtimeExtents;
+        public ulong RealtimeExtents { get; private set; }
 
         /// <summary>
         /// user-visible file system unique id
         /// </summary>
-        public Guid UniqueId;
+        public Guid UniqueId { get; private set; }
 
         /// <summary>
         /// starting block of log if internal
         /// </summary>
-        public ulong Logstart;
+        public ulong Logstart { get; private set; }
 
         /// <summary>
         /// root inode number
         /// </summary>
-        public ulong RootInode;
+        public ulong RootInode { get; private set; }
 
         /// <summary>
         /// bitmap inode for realtime extents
         /// </summary>
-        public ulong RealtimeBitmapInode;
+        public ulong RealtimeBitmapInode { get; private set; }
 
         /// <summary>
         /// summary inode for rt bitmap
         /// </summary>
-        public ulong RealtimeSummaryInode;
+        public ulong RealtimeSummaryInode { get; private set; }
 
         /// <summary>
         /// realtime extent size, blocks
         /// </summary>
-        public uint RealtimeExtentSize;
+        public uint RealtimeExtentSize { get; private set; }
 
         /// <summary>
         /// size of an allocation group
         /// </summary>
-        public uint AgBlocks;
+        public uint AgBlocks { get; private set; }
 
         /// <summary>
         /// number of allocation groups
         /// </summary>
-        public uint AgCount;
+        public uint AgCount { get; private set; }
 
         /// <summary>
         /// number of rt bitmap blocks
         /// </summary>
-        public uint RealtimeBitmapBlocks;
+        public uint RealtimeBitmapBlocks { get; private set; }
 
         /// <summary>
         /// number of log blocks
         /// </summary>
-        public uint LogBlocks;
+        public uint LogBlocks { get; private set; }
 
         /// <summary>
         /// header version == XFS_SB_VERSION
         /// </summary>
-        public ushort Version;
+        public ushort Version { get; private set; }
 
         /// <summary>
         /// volume sector size, bytes
         /// </summary>
-        public ushort SectorSize;
+        public ushort SectorSize { get; private set; }
 
         /// <summary>
         /// inode size, bytes
         /// </summary>
-        public ushort InodeSize;
+        public ushort InodeSize { get; private set; }
 
         /// <summary>
         /// inodes per block
         /// </summary>
-        public ushort InodesPerBlock;
+        public ushort InodesPerBlock { get; private set; }
 
         /// <summary>
         /// file system name
         /// </summary>
-        public string FilesystemName;
+        public string FilesystemName { get; private set; }
 
         /// <summary>
         /// log2 of <see cref="Blocksize"/>
         /// </summary>
-        public byte BlocksizeLog2;
+        public byte BlocksizeLog2 { get; private set; }
 
         /// <summary>
         /// log2 of <see cref="SectorSize"/>
         /// </summary>
-        public byte SectorSizeLog2;
+        public byte SectorSizeLog2 { get; private set; }
 
         /// <summary>
         /// log2 of <see cref="InodeSize"/>
         /// </summary>
-        public byte InodeSizeLog2;
+        public byte InodeSizeLog2 { get; private set; }
 
         /// <summary>
         /// log2 of <see cref="InodesPerBlock"/>
         /// </summary>
-        public byte InodesPerBlockLog2;
+        public byte InodesPerBlockLog2 { get; private set; }
 
         /// <summary>
         /// log2 of <see cref="AgBlocks"/> (rounded up)
         /// </summary>
-        public byte AgBlocksLog2;
+        public byte AgBlocksLog2 { get; private set; }
 
         /// <summary>
         /// log2 of <see cref="RealtimeExtents"/>
         /// </summary>
-        public byte RealtimeExtentsLog2;
+        public byte RealtimeExtentsLog2 { get; private set; }
 
         /// <summary>
         /// mkfs is in progress, don't mount
         /// </summary>
-        public byte InProgress;
+        public byte InProgress { get; private set; }
 
         /// <summary>
         /// max % of fs for inode space
         /// </summary>
-        public byte InodesMaxPercent;
+        public byte InodesMaxPercent { get; private set; }
 
-         /*
-         * These fields must remain contiguous.  If you really
-         * want to change their layout, make sure you fix the
-         * code in xfs_trans_apply_sb_deltas().
-         */                           
+        /*
+        * These fields must remain contiguous.  If you really
+        * want to change their layout, make sure you fix the
+        * code in xfs_trans_apply_sb_deltas().
+        */
         #region statistics
-        
+
         /// <summary>
         /// allocated inodes
         /// </summary>
-        public ulong AllocatedInodes;
+        public ulong AllocatedInodes { get; private set; }
 
         /// <summary>
         /// free inodes
         /// </summary>
-        public ulong FreeInodes;
+        public ulong FreeInodes { get; private set; }
 
         /// <summary>
         /// free data blocks
         /// </summary>
-        public ulong FreeDataBlocks;
+        public ulong FreeDataBlocks { get; private set; }
 
         /// <summary>
         /// free realtime extents
         /// </summary>
-        public ulong FreeRealtimeExtents;
-        
+        public ulong FreeRealtimeExtents { get; private set; }
+
         #endregion
 
         /// <summary>
         /// user quota inode
         /// </summary>
-        public ulong UserQuotaInode;
-        
+        public ulong UserQuotaInode { get; private set; }
+
         /// <summary>
         /// group quota inode
         /// </summary>
-        public ulong GroupQuotaInode;
-        
+        public ulong GroupQuotaInode { get; private set; }
+
         /// <summary>
         /// quota flags
         /// </summary>
-        public ushort QuotaFlags;
+        public ushort QuotaFlags { get; private set; }
 
         /// <summary>
         /// misc. flags
         /// </summary>
-        public byte Flags;
-        
+        public byte Flags { get; private set; }
+
         /// <summary>
         /// shared version number
         /// </summary>
-        public byte SharedVersionNumber;
-        
+        public byte SharedVersionNumber { get; private set; }
+
         /// <summary>
         /// inode chunk alignment, fsblocks
         /// </summary>
-        public uint InodeChunkAlignment;
-        
+        public uint InodeChunkAlignment { get; private set; }
+
         /// <summary>
         /// stripe or raid unit
         /// </summary>
-        public uint Unit;
-        
+        public uint Unit { get; private set; }
+
         /// <summary>
         /// stripe or raid width
         /// </summary>
-        public uint Width;
+        public uint Width { get; private set; }
 
         /// <summary>
         /// log2 of dir block size (fsbs)
         /// </summary>
-        public byte DirBlockLog2;
-        
+        public byte DirBlockLog2 { get; private set; }
+
         /// <summary>
         /// log2 of the log sector size
         /// </summary>
-        public byte LogSectorSizeLog2;
-        
+        public byte LogSectorSizeLog2 { get; private set; }
+
         /// <summary>
         /// sector size for the log, bytes
         /// </summary>
-        public ushort LogSectorSize;
-        
+        public ushort LogSectorSize { get; private set; }
+
         /// <summary>
         /// stripe unit size for the log
         /// </summary>
-        public uint LogUnitSize;
-        
+        public uint LogUnitSize { get; private set; }
+
         /// <summary>
         /// additional feature bits
         /// </summary>
-        public uint Features2;
+        public uint Features2 { get; private set; }
 
         /*
         * bad features2 field as a result of failing to pad the sb structure to
@@ -279,40 +279,43 @@ namespace DiscUtils.Xfs
         /// the value in sb_features2 when formatting the incore superblock to
         /// the disk buffer.
         /// </summary>
-        public uint BadFeatures2;
+        public uint BadFeatures2 { get; private set; }
 
         /* version 5 superblock fields start here */
 
         /* feature masks */
-        public uint CompatibleFeatures;
-        public ReadOnlyCompatibleFeatures ReadOnlyCompatibleFeatures;
-        public uint IncompatibleFeatures;
-        public uint LogIncompatibleFeatures;
+        public uint CompatibleFeatures { get; private set; }
+
+        public ReadOnlyCompatibleFeatures ReadOnlyCompatibleFeatures { get; private set; }
+
+        public uint IncompatibleFeatures { get; private set; }
+
+        public uint LogIncompatibleFeatures { get; private set; }
 
         /// <summary>
         /// superblock crc
         /// </summary>
-        public uint Crc;
+        public uint Crc { get; private set; }
 
         /// <summary>
         /// sparse inode chunk alignment
         /// </summary>
-        public uint SparseInodeAlignment;
+        public uint SparseInodeAlignment { get; private set; }
 
         /// <summary>
         /// project quota inode
         /// </summary>
-        public ulong ProjectQuotaInode;
+        public ulong ProjectQuotaInode { get; private set; }
 
         /// <summary>
         /// last write sequence
         /// </summary>
-        public long Lsn;
+        public long Lsn { get; private set; }
 
         /// <summary>
         /// metadata file system unique id
         /// </summary>
-        public Guid MetaUuid;
+        public Guid MetaUuid { get; private set; }
 
         /* must be padded to 64 bit alignment */
 

--- a/src/Xfs/Symlink.cs
+++ b/src/Xfs/Symlink.cs
@@ -43,7 +43,7 @@ namespace DiscUtils.Xfs
                 }
                 IBuffer content = FileContent;
                 byte[] data = Utilities.ReadFully(content, 0, (int) content.Capacity);
-                return Utilities.BytesToZString(data, 0, data.Length).Replace('/', '\\');
+                return Context.Options.FileNameEncoding.GetString(data, 0, data.Length).Replace('/', '\\');
             }
         }
     }

--- a/src/Xfs/VfsXfsFileSystem.cs
+++ b/src/Xfs/VfsXfsFileSystem.cs
@@ -20,7 +20,6 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-
 namespace DiscUtils.Xfs
 {
     using System;
@@ -31,7 +30,7 @@ namespace DiscUtils.Xfs
     {
         private static readonly int XFS_ALLOC_AGFL_RESERVE = 4;
 
-        public VfsXfsFileSystem(Stream stream, FileSystemParameters parameters, bool ignoreRecovery = false)
+        public VfsXfsFileSystem(Stream stream, FileSystemParameters parameters)
             :base(new XfsFileSystemOptions(parameters))
         {
             stream.Position = 0;
@@ -48,7 +47,8 @@ namespace DiscUtils.Xfs
             Context = new Context
             {
                 RawStream = stream,
-                SuperBlock = superblock
+                SuperBlock = superblock,
+                Options = (XfsFileSystemOptions) Options
             };
 
             var allocationGroups = new AllocationGroup[superblock.AgCount];
@@ -77,7 +77,7 @@ namespace DiscUtils.Xfs
         {
             if (dirEntry.IsDirectory)
             {
-                return new Directory(Context, dirEntry.Inode);
+                return dirEntry.CachedDirectory ?? (dirEntry.CachedDirectory = new Directory(Context, dirEntry.Inode));
             }
             else if (dirEntry.IsSymlink)
             {

--- a/src/Xfs/VfsXfsFileSystem.cs
+++ b/src/Xfs/VfsXfsFileSystem.cs
@@ -1,0 +1,93 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.IO;
+    using DiscUtils.Vfs;
+
+    internal sealed class VfsXfsFileSystem :VfsReadOnlyFileSystem<DirEntry, File, Directory, Context>,IUnixFileSystem
+    {
+        private AllocationGroupFreeBlockInfo[] _agf;
+
+        private static readonly int XFS_ALLOC_AGFL_RESERVE = 4;
+
+        public VfsXfsFileSystem(Stream stream, FileSystemParameters parameters, bool ignoreRecovery = false)
+            :base(new XfsFileSystemOptions(parameters))
+        {
+            stream.Position = 0;
+            byte[] superblockData = Utilities.ReadFully(stream, 264);
+
+            SuperBlock superblock = new SuperBlock();
+            superblock.ReadFrom(superblockData, 0);
+
+            if (superblock.Magic != SuperBlock.XfsMagic)
+            {
+                throw new IOException("Invalid superblock magic - probably not an xfs file system");
+            }
+
+            _agf = new AllocationGroupFreeBlockInfo[superblock.AgCount];
+            long offset = 0;
+            for (int i = 0; i < _agf.Length; i++)
+            {
+                var agf = new AllocationGroupFreeBlockInfo();
+                stream.Position = offset + superblock.SectorSize;
+                 var agfData = Utilities.ReadFully(stream, agf.Size);
+                agf.ReadFrom(agfData, 0);
+                if (agf.Magic != AllocationGroupFreeBlockInfo.AgfMagic)
+                {
+                    throw new IOException("Invalid AGF magic - probably not an xfs file system");
+                }
+                _agf[i] = agf;
+                offset += agf.Length*superblock.Blocksize;
+            }
+
+            Context = new Context
+            {
+                RawStream = stream,
+                SuperBlock = superblock
+            };
+        }
+        
+        public override string FriendlyName
+        {
+            get { return "XFS"; }
+        }
+
+        /// <inheritdoc />
+        public override string VolumeLabel { get { return Context.SuperBlock.FilesystemName; } }
+
+        /// <inheritdoc />
+        protected override File ConvertDirEntryToFile(DirEntry dirEntry)
+        {
+            throw new NotImplementedException();
+        }
+        
+        public UnixFileSystemInfo GetUnixFileInfo(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+    }
+}

--- a/src/Xfs/VfsXfsFileSystem.cs
+++ b/src/Xfs/VfsXfsFileSystem.cs
@@ -81,7 +81,7 @@ namespace DiscUtils.Xfs
             }
             else if (dirEntry.IsSymlink)
             {
-                throw new NotImplementedException();
+                return new Symlink(Context, dirEntry.Inode);
             }
             else if (dirEntry.Inode.FileType == UnixFileType.Regular)
             {

--- a/src/Xfs/VfsXfsFileSystem.cs
+++ b/src/Xfs/VfsXfsFileSystem.cs
@@ -29,7 +29,7 @@ namespace DiscUtils.Xfs
 
     internal sealed class VfsXfsFileSystem :VfsReadOnlyFileSystem<DirEntry, File, Directory, Context>,IUnixFileSystem
     {
-        private AllocationGroup[] _allocationGroups;
+        private readonly AllocationGroup[] _allocationGroups;
 
         private static readonly int XFS_ALLOC_AGFL_RESERVE = 4;
 
@@ -47,20 +47,20 @@ namespace DiscUtils.Xfs
                 throw new IOException("Invalid superblock magic - probably not an xfs file system");
             }
 
-            _allocationGroups = new AllocationGroup[superblock.AgCount];
-            long offset = 0;
-            for (int i = 0; i < _allocationGroups.Length; i++)
-            {
-                var ag = new AllocationGroup(superblock, stream, offset);
-                _allocationGroups[i] = ag;
-                offset += ag.FreeBlockInfo.Length*superblock.Blocksize;
-            }
-
             Context = new Context
             {
                 RawStream = stream,
                 SuperBlock = superblock
             };
+
+            _allocationGroups = new AllocationGroup[superblock.AgCount];
+            long offset = 0;
+            for (int i = 0; i < _allocationGroups.Length; i++)
+            {
+                var ag = new AllocationGroup(Context, offset);
+                _allocationGroups[i] = ag;
+                offset += ag.FreeBlockInfo.Length*superblock.Blocksize;
+            }
 
             //TODO RootDirectory = new Directory(Context, superblock.RootInode, GetInode(superblock.RootInode));
         }

--- a/src/Xfs/VfsXfsFileSystem.cs
+++ b/src/Xfs/VfsXfsFileSystem.cs
@@ -28,8 +28,6 @@ namespace DiscUtils.Xfs
 
     internal sealed class VfsXfsFileSystem :VfsReadOnlyFileSystem<DirEntry, File, Directory, Context>,IUnixFileSystem
     {
-        private static readonly int XFS_ALLOC_AGFL_RESERVE = 4;
-
         public VfsXfsFileSystem(Stream stream, FileSystemParameters parameters)
             :base(new XfsFileSystemOptions(parameters))
         {

--- a/src/Xfs/XfsFileSystem.cs
+++ b/src/Xfs/XfsFileSystem.cs
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System.IO;
+    using DiscUtils.Vfs;
+
+    /// <summary>
+    /// Read-only access to ext file system.
+    /// </summary>
+    public sealed class XfsFileSystem : VfsFileSystemFacade, IUnixFileSystem
+    {
+        /// <summary>
+        /// Initializes a new instance of the ExtFileSystem class.
+        /// </summary>
+        /// <param name="stream">The stream containing the ext file system.</param>
+        public XfsFileSystem(Stream stream)
+            : base(new VfsXfsFileSystem(stream, null))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ExtFileSystem class.
+        /// </summary>
+        /// <param name="stream">The stream containing the ext file system.</param>
+        /// <param name="parameters">The generic file system parameters (only file name encoding is honoured).</param>
+        /// <param name="ignoreRecovery">Ignore the Incompatible ext feature NeedsRecovery</param>
+        public XfsFileSystem(Stream stream, FileSystemParameters parameters, bool ignoreRecovery = false)
+            : base(new VfsXfsFileSystem(stream, parameters, ignoreRecovery))
+        {
+        }
+
+        /// <summary>
+        /// Retrieves Unix-specific information about a file or directory.
+        /// </summary>
+        /// <param name="path">Path to the file or directory.</param>
+        /// <returns>Information about the owner, group, permissions and type of the
+        /// file or directory.</returns>
+        public UnixFileSystemInfo GetUnixFileInfo(string path)
+        {
+            return GetRealFileSystem<VfsXfsFileSystem>().GetUnixFileInfo(path);
+        }
+
+        internal static bool Detect(Stream stream)
+        {
+            if (stream.Length < 264)
+            {
+                return false;
+            }
+
+            stream.Position = 0;
+            byte[] superblockData = Utilities.ReadFully(stream, 264);
+
+            SuperBlock superblock = new SuperBlock();
+            superblock.ReadFrom(superblockData, 0);
+
+            return superblock.Magic == SuperBlock.XfsMagic;
+        }
+    }
+}

--- a/src/Xfs/XfsFileSystem.cs
+++ b/src/Xfs/XfsFileSystem.cs
@@ -44,7 +44,6 @@ namespace DiscUtils.Xfs
         /// </summary>
         /// <param name="stream">The stream containing the ext file system.</param>
         /// <param name="parameters">The generic file system parameters (only file name encoding is honoured).</param>
-        /// <param name="ignoreRecovery">Ignore the Incompatible ext feature NeedsRecovery</param>
         public XfsFileSystem(Stream stream, FileSystemParameters parameters)
             : base(new VfsXfsFileSystem(stream, parameters))
         {

--- a/src/Xfs/XfsFileSystem.cs
+++ b/src/Xfs/XfsFileSystem.cs
@@ -45,8 +45,8 @@ namespace DiscUtils.Xfs
         /// <param name="stream">The stream containing the ext file system.</param>
         /// <param name="parameters">The generic file system parameters (only file name encoding is honoured).</param>
         /// <param name="ignoreRecovery">Ignore the Incompatible ext feature NeedsRecovery</param>
-        public XfsFileSystem(Stream stream, FileSystemParameters parameters, bool ignoreRecovery = false)
-            : base(new VfsXfsFileSystem(stream, parameters, ignoreRecovery))
+        public XfsFileSystem(Stream stream, FileSystemParameters parameters)
+            : base(new VfsXfsFileSystem(stream, parameters))
         {
         }
 

--- a/src/Xfs/XfsFileSystemOptions.cs
+++ b/src/Xfs/XfsFileSystemOptions.cs
@@ -1,0 +1,41 @@
+﻿//
+// Copyright (c) 2016, Bianco Veigel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+namespace DiscUtils.Xfs
+{
+    using System;
+    using System.Text;
+
+    /// <summary>
+    /// XFS file system options.
+    /// </summary>
+    public sealed class XfsFileSystemOptions : DiscFileSystemOptions
+    {
+        internal XfsFileSystemOptions()
+        {
+        }
+
+        internal XfsFileSystemOptions(FileSystemParameters parameters)
+        {
+        }
+    }
+}


### PR DESCRIPTION
The implementation is based on the (probably outdated) [spec](http://oss.sgi.com/projects/xfs/papers/xfs_filesystem_structure.pdf).
The following features were verified against a virtual disk created by an Ubuntu 14.04 (3.13.0-98-generic):

- Directories
  - Shortform
  - Block
  - Leaf/Node without leaf and freeindex
  - B+tree
- Inodes / Files / Symlinks
  - Local
  - Extent
  - B+tree

All on-disk formats were validated by an artificially created structure (directories with > 300000 entries, heavily fragmented files with > 3000 extents). All parsed block and inode numbers were compared to the output of [xfs_db](https://linux.die.net/man/8/xfs_db)

Currently unsupported features;
- Attributes
- Quota
- Journaling (as it's undocumented)