### PR TITLE
Fix VHD relative path resolution for diff disks.

### DIFF
--- a/src/Utilities.cs
+++ b/src/Utilities.cs
@@ -694,52 +694,25 @@ namespace DiscUtils
         /// </summary>
         /// <param name="basePath">The base path to resolve from.</param>
         /// <param name="relativePath">The relative path.</param>
-        /// <returns>The absolute path, so far as it can be resolved.  If the
-        /// <paramref name="relativePath"/> contains more '..' characters than the
-        /// base path contains levels of directory, the resultant string will be relative.
-        /// For example: (TEMP\Foo.txt, ..\..\Bar.txt) gives (..\Bar.txt).</returns>
+        /// <returns>The absolute path. If no <paramref name="basePath"/> is specified
+        /// then relativePath is returned as-is. If <paramref name="relativePath"/>
+        /// contains more '..' characters than the base path contains levels of 
+        /// directory, the resultant string be the root drive followed by the file name.
+        /// If no the basePath starts with '\' (no drive specified) then the returned
+        /// path will also start with '\'.
+        /// For example: (\TEMP\Foo.txt, ..\..\Bar.txt) gives (\Bar.txt).</returns>
         public static string ResolveRelativePath(string basePath, string relativePath)
         {
-            List<string> pathElements = new List<string>(basePath.Split(new char[] { '\\' }, StringSplitOptions.RemoveEmptyEntries));
-            if (!basePath.EndsWith(@"\", StringComparison.Ordinal) && pathElements.Count > 0)
+            if (string.IsNullOrEmpty(basePath))
             {
-                pathElements.RemoveAt(pathElements.Count - 1);
+                return relativePath;
             }
 
-            pathElements.AddRange(relativePath.Split(new char[] { '\\' }, StringSplitOptions.RemoveEmptyEntries));
+            string merged = Path.GetFullPath(Path.Combine(basePath, relativePath));
 
-            int pos = 1;
-            while (pos < pathElements.Count)
+            if (basePath.StartsWith(@"\") && merged[1].Equals(':'))
             {
-                if (pathElements[pos] == ".")
-                {
-                    pathElements.RemoveAt(pos);
-                }
-                else if (pathElements[pos] == ".." && pos > 0 && pathElements[pos - 1][0] != '.')
-                {
-                    pathElements.RemoveAt(pos);
-                    pathElements.RemoveAt(pos - 1);
-                    pos--;
-                }
-                else
-                {
-                    pos++;
-                }
-            }
-
-            string merged = string.Join(@"\", pathElements.ToArray());
-            if (relativePath.EndsWith(@"\", StringComparison.Ordinal))
-            {
-                merged += @"\";
-            }
-
-            if (basePath.StartsWith(@"\\", StringComparison.Ordinal))
-            {
-                merged = @"\\" + merged;
-            }
-            else if (basePath.StartsWith(@"\", StringComparison.Ordinal))
-            {
-                merged = @"\" + merged;
+                return merged.Substring(2);
             }
 
             return merged;


### PR DESCRIPTION
This change addresses an issue where the following code fails when the differencing disk contains a relative path for a parent disk:
`var disk = new Disk(differencingDiskPath, FileAccess.ReadWrite)`

The old code for ResolveRelativePath would trim the leaf directory off the base path if it didn't end with a backslash, resulting in `ResolveRelativePath(@"c:\temp\subdir", ".\image.vhd"`) returning c:\temp\image.vhd instead of c:\temp\subdir\image.vhd.

I did not see any obvious places where my change will break anything and all unit tests are passing.